### PR TITLE
Remove Polldaddy Polls header when previewing a poll

### DIFF
--- a/polldaddy.php
+++ b/polldaddy.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Plugin Name: Crowdsignal Polls & Ratings
  * Plugin URI: http://wordpress.org/extend/plugins/polldaddy/
@@ -1303,10 +1302,7 @@ class WP_Polldaddy {
 			switch ( $action ) {
 			case 'preview' :
 				if ( isset( $_GET['iframe'] ) ):
-					if ( !isset( $_GET['popup'] ) ) { ?>
-				<h2 id="poll-list-header"><?php _e( 'Polldaddy Polls', 'polldaddy' ); ?></h2>
-<?php
-					} else { ?>
+					if ( isset( $_GET['popup'] ) ) { ?>
 				<h2 id="poll-list-header"><?php printf( __( 'Preview Poll <a href="%s" class="add-new-h2">All Polls</a>', 'polldaddy' ), esc_url( add_query_arg( array( 'action' => 'polls', 'poll' => false, 'message' => false ) ) ) ); ?></h2>
 <?php
 					}


### PR DESCRIPTION
Ref: https://trello.com/c/t03Wgv7O/6-polldaddy-displayed-in-preview-window

This removes the header `Polldaddy Polls` when previewing a poll. From WP Admin > Crowdsignal > Polls > [hover over one poll] _Preview_.

Before:
<img width="790" alt="Screen Shot 2019-12-11 at 11 26 17 AM" src="https://user-images.githubusercontent.com/68693/70617677-115fdd00-1c09-11ea-927f-e714d348957f.png">


After:
<img width="897" alt="Screen Shot 2019-12-11 at 11 25 07 AM" src="https://user-images.githubusercontent.com/68693/70617656-01e09400-1c09-11ea-9577-7254bd9755b7.png">
