### PR TITLE
Match normal WordPress classic post edit screen in poll editor

### DIFF
--- a/css/polldaddy.css
+++ b/css/polldaddy.css
@@ -10,7 +10,7 @@ abbr{
 
 hr{
 	border: 1px #EFEFEF solid;
-	
+
 }
 
 #polldaddy-error.error a{
@@ -21,6 +21,10 @@ hr{
 
 h2 a.button{
 	font-family: Lucida Grande, Arial, Sans;
+}
+
+.postbox h2.postbox-title {
+	border-bottom: 1px solid #ccd0d4;
 }
 
 #pd-wrap .postbox .inside{
@@ -71,7 +75,7 @@ td#signup-button{
 }
 
 td a.row-title{
-	/*font-size: 14px;*/	
+	/*font-size: 14px;*/
 }
 
 ul#answers li span.handle{
@@ -146,7 +150,7 @@ ul.pd-tabs li.selected{
 	border: 1px #dfdfdf solid;
 	border-radius: 3px 3px 0px 0px;
 	border-bottom: 0px;
-	margin-right: 5px;	
+	margin-right: 5px;
 }
 
 ul.cs-tabs li a,
@@ -161,7 +165,6 @@ ul.pd-tabs li.selected a{
 
 .cs-tab-panel,
 .pd-tab-panel{
-	height: 300px;
 	border: 1px #dfdfdf solid;
 	margin-top:-7px;
 	display: none;
@@ -207,7 +210,7 @@ input#shortcode-field{
 }
 
 .answer-media{
-	
+
 }
 
 .answer-media li{
@@ -270,57 +273,57 @@ word-wrap: break-word;
 
 /* OLD STYLES, PRE-2.0 ------------------------------------------------------------
 ---------------------------------------------------------------------------------------------------*/
-body.poll-preview-iframe{min-width:0;} 
-body.poll-preview-iframe #sidemenu, body.poll-preview-iframe #submenu, body.poll-preview-iframe #wpadminbar, body.poll-preview-iframe #wphead, body.poll-preview-iframe #gears-info-box, body.poll-preview-iframe #user_info, body.poll-preview-iframe #dashmenu, body.poll-preview-iframe #adminmenu, body.poll-preview-iframe #sidemenu-bg, body.poll-preview-iframe #footer, body.poll-preview-iframe #feedbacklink, body.poll-preview-iframe #screen-meta, body.poll-preview-iframe #manage-polls h2#preview-header{display:none;} body.poll-preview-iframe-editor #manage-polls h2#preview-header{display:block;} 
-body.poll-preview-iframe h2{padding-top:0;} 
-body.poll-preview-iframe{margin:0 !important;padding:0 !important;} 
-body.poll-preview-iframe .wrap{max-width:100%;} 
-body.poll-preview-iframe #wpwrap{min-height:0;} 
-body.poll-preview-iframe div#wpcontent{margin:0;padding:0;} 
+body.poll-preview-iframe{min-width:0;}
+body.poll-preview-iframe #sidemenu, body.poll-preview-iframe #submenu, body.poll-preview-iframe #wpadminbar, body.poll-preview-iframe #wphead, body.poll-preview-iframe #gears-info-box, body.poll-preview-iframe #user_info, body.poll-preview-iframe #dashmenu, body.poll-preview-iframe #adminmenu, body.poll-preview-iframe #sidemenu-bg, body.poll-preview-iframe #footer, body.poll-preview-iframe #feedbacklink, body.poll-preview-iframe #screen-meta, body.poll-preview-iframe #manage-polls h2#preview-header{display:none;} body.poll-preview-iframe-editor #manage-polls h2#preview-header{display:block;}
+body.poll-preview-iframe h2{padding-top:0;}
+body.poll-preview-iframe{margin:0 !important;padding:0 !important;}
+body.poll-preview-iframe .wrap{max-width:100%;}
+body.poll-preview-iframe #wpwrap{min-height:0;}
+body.poll-preview-iframe div#wpcontent{margin:0;padding:0;}
 body.poll-preview-iframe div#wpbody{margin:0;padding:2em 3em;text-align:center;}
-body.poll-preview-iframe div#wpbody-content{margin:0;padding:0;border:none;} 
-body.poll-preview-iframe div#manage-polls.wrap{text-align:left;} 
-body.poll-preview-iframe .pds-box{margin-left:auto;margin-right:auto;} 
-table td.post-title strong{display:block;} 
-table.poll-results .column-vote{padding:3px 5px 3px 3px;margin:0;} 
-table.poll-results div.result-holder{position:relative;} 
-table.poll-results span.result-bar{display:block;padding:5px 0 4px 0;margin:0;height:100%;border:1px solid #EDB918;background-color:#FBD55E;} 
-table.poll-results span.result-total{position:absolute;left:.75em;top:6px;} 
-table.poll-results span.result-percent{position:absolute;right:.75em;top:6px;} 
-table.poll-others{margin-top:1.5em;} 
-table.poll-others .column-vote{min-width:50%;} 
-ul#answers,ul.poll-options{list-style:none;padding:0;} 
-ul#answers li{position:relative;} 
-ul#answers li span.handle{width:18px;height:100%;cursor:move;text-align:center;line-height:1.8em;} 
-ul#answers input{padding:0;border:none;float:left;margin-right: 0px; width:100%;border:1px solid #ccc;padding:2px 3px;margin-left: 3px;} 
-p.submit input{padding:6px;} 
-p#add-answer-holder{display:none;text-align:left;padding-left:10px;} 
-.inner-sidebar-ratings{clear:right;float:right;position:relative;width:281px;} 
-#poststuff #post-body.has-sidebar,.has-sidebar{clear:left;float:left;margin-right:-240px;width:100%;} 
-.has-sidebar .has-sidebar-content{margin-right:245px;} 
+body.poll-preview-iframe div#wpbody-content{margin:0;padding:0;border:none;}
+body.poll-preview-iframe div#manage-polls.wrap{text-align:left;}
+body.poll-preview-iframe .pds-box{margin-left:auto;margin-right:auto;}
+table td.post-title strong{display:block;}
+table.poll-results .column-vote{padding:3px 5px 3px 3px;margin:0;}
+table.poll-results div.result-holder{position:relative;}
+table.poll-results span.result-bar{display:block;padding:5px 0 4px 0;margin:0;height:100%;border:1px solid #EDB918;background-color:#FBD55E;}
+table.poll-results span.result-total{position:absolute;left:.75em;top:6px;}
+table.poll-results span.result-percent{position:absolute;right:.75em;top:6px;}
+table.poll-others{margin-top:1.5em;}
+table.poll-others .column-vote{min-width:50%;}
+ul#answers,ul.poll-options{list-style:none;padding:0;}
+ul#answers li{position:relative;}
+ul#answers li span.handle{width:18px;height:100%;cursor:move;text-align:center;line-height:1.8em;}
+ul#answers input{padding:0;border:none;float:left;margin-right: 0px; width:100%;border:1px solid #ccc;padding:2px 3px;margin-left: 3px;}
+p.submit input{padding:6px;}
+p#add-answer-holder{display:none;text-align:left;padding-left:10px;}
+.inner-sidebar-ratings{clear:right;float:right;position:relative;width:281px;}
+#poststuff #post-body.has-sidebar,.has-sidebar{clear:left;float:left;margin-right:-240px;width:100%;}
+.has-sidebar .has-sidebar-content{margin-right:245px;}
 #post-body-content #titlediv{margin:10px 0;}
-tr.polldaddy-shortcode-row{} 
-tr.polldaddy-shortcode-row h4{padding:0;margin:0.3em 0;clear:both;} 
+tr.polldaddy-shortcode-row{}
+tr.polldaddy-shortcode-row h4{padding:0;margin:0.3em 0;clear:both;}
 tr.polldaddy-shortcode-row pre{float:left;background-color:#fff;padding:.2em;margin:0 0 .5em;border:1px solid #ccc;}
-tr.polldaddy-shortcode-row input{float:left;background-color:#fff;border:1px solid #ccc;padding:0.5em 0;margin:0 0 0.5em;font-size:11px;font-family:monospace;color: rgb(51, 51, 51);-moz-border-radius: 0px;} 
-.polldaddy-show-design-options{text-align:left;width:8em;display:block;font-size:1em;padding:1em 2em;text-decoration:none;} 
- #design h3{text-align:left;} 
-#design_standard{display:block;padding:0px 0px 0px 20px;} 
-#design_standard a{width:1em;font-size:4em;text-decoration:none;} 
-#design_custom {display:none;} 
-.pollStyle{width:100%;border-collapse:collapse;} 
-.pollStyle .cb{height:40px;width:30px;padding:0px 0px 2px 0px;} 
-.pollStyle .selector{width:250px;} 
-.pollStyle .customSelect{vertical-align:top;text-align:left;margin:0px;} 
-.pollStyle TH{text-align:left;} 
-.st_selector{border-collapse:collapse;} 
-.st_selector .img{width:150px;padding:0px;margin:0px;height:200px;} 
+tr.polldaddy-shortcode-row input{float:left;background-color:#fff;border:1px solid #ccc;padding:0.5em 0;margin:0 0 0.5em;font-size:11px;font-family:monospace;color: rgb(51, 51, 51);-moz-border-radius: 0px;}
+.polldaddy-show-design-options{text-align:left;width:8em;display:block;font-size:1em;padding:1em 2em;text-decoration:none;}
+ #design h3{text-align:left;}
+#design_standard{display:block;padding:0px 0px 0px 20px;}
+#design_standard a{width:1em;font-size:4em;text-decoration:none;}
+#design_custom {display:none;}
+.pollStyle{width:100%;border-collapse:collapse;}
+.pollStyle .cb{height:40px;width:30px;padding:0px 0px 2px 0px;}
+.pollStyle .selector{width:250px;}
+.pollStyle .customSelect{vertical-align:top;text-align:left;margin:0px;}
+.pollStyle TH{text-align:left;}
+.st_selector{border-collapse:collapse;}
+.st_selector .img{width:150px;padding:0px;margin:0px;height:200px;}
 .st_selector .dir_left{padding:0px 10px 0px 0px;width:75px;}
-.st_selector .dir_right{padding:0px 0px 0px 20px;width:75px;} 
-.st_selector .title{text-align:center;height:20px;font-weight:bold;} 
-.st_selector .counter{text-align:center;width:150px;padding:10px 0px 0px 0px;} 
-#st_image{width:150px;padding:0px;margin:0px;height:200px;} 
-#st_sizes{width:152px;text-align:center;font-size:12px;} 
-#st_sizes a{width:150px;text-align:center;font-size:12px;} 
-.st_image_loader{width:150px;padding:0px;margin:0px;background:url(../img/st-loader.gif) no-repeat center center;} 
+.st_selector .dir_right{padding:0px 0px 0px 20px;width:75px;}
+.st_selector .title{text-align:center;height:20px;font-weight:bold;}
+.st_selector .counter{text-align:center;width:150px;padding:10px 0px 0px 0px;}
+#st_image{width:150px;padding:0px;margin:0px;height:200px;}
+#st_sizes{width:152px;text-align:center;font-size:12px;}
+#st_sizes a{width:150px;text-align:center;font-size:12px;}
+.st_image_loader{width:150px;padding:0px;margin:0px;background:url(../img/st-loader.gif) no-repeat center center;}
 #st_description{padding:6px 0px;font-size:9px;width:300px;text-align:center;}

--- a/css/polldaddy.css
+++ b/css/polldaddy.css
@@ -23,7 +23,7 @@ h2 a.button{
 	font-family: Lucida Grande, Arial, Sans;
 }
 
-.postbox h2.postbox-title {
+#manage-polls .postbox h2.postbox-title {
 	border-bottom: 1px solid #ccd0d4;
 }
 

--- a/polldaddy.php
+++ b/polldaddy.php
@@ -1800,7 +1800,7 @@ src="https://static.polldaddy.com/p/<?php echo (int) $poll_id; ?>.js"&gt;&lt;/sc
 
 <div class="inner-sidebar" id="side-info-column">
 	<div id="submitdiv" class="postbox">
-		<h3><?php _e( 'Save', 'polldaddy' ); ?></h3>
+		<h2 class="postbox-title"><?php _e( 'Save', 'polldaddy' ); ?></h2>
 		<div class="inside">
 		<div class="minor-publishing">
 
@@ -1847,21 +1847,8 @@ src="https://static.polldaddy.com/p/<?php echo (int) $poll_id; ?>.js"&gt;&lt;/sc
 			</p>
 		</div>
 	</div>
-
-
-
 			<div id="major-publishing-actions">
-
-
-
-
-
-
-
-				<p id="publishing-action">
-
-
-
+				<div id="publishing-action">
 					<?php wp_nonce_field( $poll_id ? "edit-poll_$poll_id" : 'create-poll' ); ?>
 					<input type="hidden" name="action" value="<?php echo $poll_id ? 'edit-poll' : 'create-poll'; ?>" />
 					<input type="hidden" class="polldaddy-poll-id" name="poll" value="<?php echo $poll_id; ?>" />
@@ -1873,14 +1860,14 @@ src="https://static.polldaddy.com/p/<?php echo (int) $poll_id; ?>.js"&gt;&lt;/sc
 					</div>
 <?php endif; ?>
 
-				</p>
+				</div>
 				<br class="clear" />
 			</div>
 		</div>
 	</div>
 
 	<div class="postbox">
-		<h3><?php _e( 'Results Display', 'polldaddy' ); ?></h3>
+		<h2 class="postbox-title"><?php _e( 'Results Display', 'polldaddy' ); ?></h2>
 		<div class="inside">
 			<ul class="poll-options">
 
@@ -1903,7 +1890,7 @@ src="https://static.polldaddy.com/p/<?php echo (int) $poll_id; ?>.js"&gt;&lt;/sc
 	</div>
 
 	<div class="postbox">
-		<h3><?php _e( 'Repeat Voting', 'polldaddy' ); ?></h3>
+		<h2 class="postbox-title"><?php _e( 'Repeat Voting', 'polldaddy' ); ?></h2>
 		<div class="inside">
 			<ul class="poll-options">
 
@@ -1941,7 +1928,7 @@ src="https://static.polldaddy.com/p/<?php echo (int) $poll_id; ?>.js"&gt;&lt;/sc
 	</div>
 
 	<div class="postbox">
-		<h3><?php _e( 'Comments', 'polldaddy' ); ?></h3>
+		<h2 class="postbox-title"><?php _e( 'Comments', 'polldaddy' ); ?></h2>
 		<div class="inside">
 			<ul class="poll-options">
 
@@ -2019,7 +2006,7 @@ src="https://static.polldaddy.com/p/<?php echo (int) $poll_id; ?>.js"&gt;&lt;/sc
 	</div>
 
 	<div id="answersdiv" class="postbox">
-		<h3><?php _e( 'Answers', 'polldaddy' ); ?></h3>
+		<h2 class="postbox-title"><?php _e( 'Answers', 'polldaddy' ); ?></h2>
 
 		<div id="answerswrap" class="inside">
 		<ul id="answers">
@@ -2029,10 +2016,7 @@ src="https://static.polldaddy.com/p/<?php echo (int) $poll_id; ?>.js"&gt;&lt;/sc
 			$a++;
 		$delete_link = esc_url( wp_nonce_url( add_query_arg( array( 'action' => 'delete-answer', 'poll' => $poll_id, 'answer' => $answer_id, 'message' => false ) ), "delete-answer_$answer_id" ) );
 ?>
-
 			<li>
-
-
 				<table class="answer">
 
 						<tr>
@@ -2072,8 +2056,7 @@ src="https://static.polldaddy.com/p/<?php echo (int) $poll_id; ?>.js"&gt;&lt;/sc
 							</td>
 						</tr>
 					</table>
-
-
+				
 								</li>
 
 <?php
@@ -2223,7 +2206,7 @@ src="https://static.polldaddy.com/p/<?php echo (int) $poll_id; ?>.js"&gt;&lt;/sc
 			$custom_style_ID = 0;
 		}
 ?>
-		<h3><?php _e( 'Poll Style', 'polldaddy' ); ?></h3>
+		<h2 class="postbox-title"><?php _e( 'Poll Style', 'polldaddy' ); ?></h2>
 		<input type="hidden" name="styleID" id="styleID" value="<?php echo $style_ID ?>">
 		<div class="inside">
 
@@ -4061,7 +4044,7 @@ src="https://static.polldaddy.com/p/<?php echo (int) $poll_id; ?>.js"&gt;&lt;/sc
         <div  class="has-sidebar has-right-sidebar">
           <div class="inner-sidebar-ratings">
            <div id="submitdiv" class="postbox ">
-			    <h3 class="hndle"><span><?php _e( 'Save Advanced Settings', 'polldaddy' );?></span></h3>
+			    <h2 class="postbox-title"><span><?php _e( 'Save Advanced Settings', 'polldaddy' );?></span></h2>
 
 			    <div class="inside">
 			        <div class="submitbox" id="submitpost">
@@ -4075,7 +4058,7 @@ src="https://static.polldaddy.com/p/<?php echo (int) $poll_id; ?>.js"&gt;&lt;/sc
 			    </div>
 			</div>
             <div class="postbox">
-              <h3><?php _e( 'Preview', 'polldaddy' );?></h3>
+              <h2 class="postbox-title"><?php _e( 'Preview', 'polldaddy' );?></h2>
               <div class="inside">
                 <p><?php _e( 'This is a demo of what your rating widget will look like', 'polldaddy' ); ?>.</p>
                 <p>
@@ -4084,7 +4067,7 @@ src="https://static.polldaddy.com/p/<?php echo (int) $poll_id; ?>.js"&gt;&lt;/sc
               </div>
             </div>
             <div class="postbox">
-              <h3><?php _e( 'Customize Labels', 'polldaddy' );?></h3>
+              <h2 class="postbox-title"><?php _e( 'Customize Labels', 'polldaddy' );?></h2>
               <div class="inside">
                 <table width="99.5%">
                   <tr>
@@ -4207,7 +4190,7 @@ src="https://static.polldaddy.com/p/<?php echo (int) $poll_id; ?>.js"&gt;&lt;/sc
           </div>
           <div id="post-body-content" class="has-sidebar-content">
             <div class="postbox">
-              <h3><?php _e( 'Rating Type', 'polldaddy' );?></h3>
+              <h2 class="postbox-title"><?php _e( 'Rating Type', 'polldaddy' );?></h2>
               <div class="inside">
                 <p><?php _e( 'Here you can choose how you want your rating to display. The 5 star rating is the most commonly used. The Nero rating is useful for keeping it simple.', 'polldaddy' ); ?></p>
                   <ul>
@@ -4233,7 +4216,7 @@ src="https://static.polldaddy.com/p/<?php echo (int) $poll_id; ?>.js"&gt;&lt;/sc
                 </div>
             </div>
           <div class="postbox">
-            <h3><?php _e( 'Rating Style', 'polldaddy' );?></h3>
+            <h2 class="postbox-title"><?php _e( 'Rating Style', 'polldaddy' );?></h2>
             <div class="inside">
               <table>
                 <tr>
@@ -4281,7 +4264,7 @@ src="https://static.polldaddy.com/p/<?php echo (int) $poll_id; ?>.js"&gt;&lt;/sc
             </div>
           </div>
           <div class="postbox">
-            <h3><?php _e( 'Text Layout & Font', 'polldaddy' );?></h3>
+            <h2 class="postbox-title"><?php _e( 'Text Layout & Font', 'polldaddy' );?></h2>
             <div class="inside">
               <table>
                 <tr>
@@ -4381,7 +4364,7 @@ src="https://static.polldaddy.com/p/<?php echo (int) $poll_id; ?>.js"&gt;&lt;/sc
           <?php
 				if ( $this->is_admin ) { ?>
             <div class="postbox">
-              <h3><?php _e( 'Extra Settings', 'polldaddy' );?></h3>
+              <h2 class="postbox-title"><?php _e( 'Extra Settings', 'polldaddy' );?></h2>
               <div class="inside">
                 <table>
                   <tr>


### PR DESCRIPTION
Ref: https://trello.com/c/84WqyASi/3-fix-padding-margins-in-poll-editor

_Review Note_: New `.editorconfig` stripped whitespace at end of lines. Especially when reviewing CSS file, might be best to hide whitespace changes.

This fixes a few style issues in the Poll editor, including:
- Post boxes: Switching from `<h3/>` to `<h2/>` to get WP core's styles. This matches the appearance in the WP classic editor. Since we can't reorder these post boxes, I also copied the border style from `hndle` in WP core to give post box headers the border style.
- Style chooser: took out the explicit `height` to fix the issue with the text going over the border.
- Use `<div />` instead of `<p />` around the poll `Save Poll` button to match core's classic editor `Save` in `#major-publishing-actions`.

@roundhill In the Trello issue, I wasn't sure what the top-left arrow was referring to.

Before:
<img width="1528" alt="Screen Shot 2019-12-11 at 12 25 39 PM" src="https://user-images.githubusercontent.com/68693/70621406-63a4fc00-1c11-11ea-9ca6-aaafdd136748.png">

After:
<img width="1528" alt="Screen Shot 2019-12-11 at 12 25 14 PM" src="https://user-images.githubusercontent.com/68693/70621411-669fec80-1c11-11ea-8101-f9d62586f108.png">

