### PR TITLE
Move settings to the Crowdsignal section

### DIFF
--- a/polldaddy.php
+++ b/polldaddy.php
@@ -139,7 +139,13 @@ class WP_Polldaddy {
 			add_action( "load-$hook", array( &$this, 'management_page_load' ) );
 
 			add_submenu_page( 'feedback', $page_title, $page_title, $capability, $menu_slug, $function );
-			add_options_page( $page_title, $page_title, $menu_slug == 'ratings' ? 'manage_options' : $capability, $menu_slug.'&action=options', $function );
+		}
+
+		// Add settings pages.
+		foreach( array( 'polls' => __( 'Poll', 'polldaddy' ), 'ratings' => __( 'Rating', 'polldaddy' ) ) as $menu_slug => $page_title ) {
+			// translators: %s placeholder is the setting page type (Poll or Rating).
+			$settings_page_title = sprintf( esc_html__( '%s Settings', 'polldaddy' ), $page_title );
+			add_submenu_page( 'feedback', $settings_page_title, $settings_page_title, $menu_slug == 'ratings' ? 'manage_options' : $capability, $menu_slug.'&action=options', $function );
 		}
 
 		remove_submenu_page( 'feedback', 'feedback' );
@@ -2052,7 +2058,7 @@ src="https://static.polldaddy.com/p/<?php echo (int) $poll_id; ?>.js"&gt;&lt;/sc
 							</td>
 						</tr>
 					</table>
-				
+
 								</li>
 
 <?php


### PR DESCRIPTION
Ref https://trello.com/c/BawHDYUC/9-rename-polls-to-crowdsignal-in-settings

This moves the pages for Polls and Rating settings from Settings to the Crowdsignal header. I was considering _adding_ a new page for Connection settings, because technically the _Polls Settings_ is mostly 

I tried merging them, but it was much more difficult than I initially thought. The classes for `WP_Polldaddy` and `WPORG_Polldaddy` have some interplay here that will need more research and didn't want to break `WPCOM_Polldaddy` if we ever merge. The functions for these pages are all interwoven through several functions within `WP_Polldaddy`. 