### PR TITLE
Fix `Multiple Choice` poll settings

### DIFF
--- a/polldaddy.php
+++ b/polldaddy.php
@@ -1090,6 +1090,10 @@ class WP_Polldaddy {
 						$user_defaults[$option] = 'no';
 				}
 
+				if ( ! empty( $_POST['multipleChoice'] ) ) {
+					$user_defaults['choices'] = 1;
+				}
+
 				$results = array( 'show', 'percent', 'hide' );
 				if ( isset( $_POST['resultsType'] ) && in_array( $_POST['resultsType'], $results ) )
 					$user_defaults['resultsType'] = $_POST['resultsType'];
@@ -1824,7 +1828,7 @@ src="https://static.polldaddy.com/p/<?php echo (int) $poll_id; ?>.js"&gt;&lt;/sc
 			$style = 'yes' === $poll->multipleChoice ? 'display:block;' : 'display:none;';
 ?>
 		<div id="numberChoices" name="numberChoices" style="padding-left:15px;<?php echo $style; ?>">
-			<p><?php _e( 'Number of choices', 'polldaddy' ) ?>: <select name="choices" id="choices"><option value="0"><?php _e( 'No Limit', 'polldaddy' ) ?></option>
+			<p><?php _e( 'Number of choices', 'polldaddy' ) ?>: <select name="choices" id="choices"><option value="1"><?php _e( 'No Limit', 'polldaddy' ) ?></option>
 				<?php
 		if ( $is_POST )
 			$choices = (int) $_POST['choices'];


### PR DESCRIPTION
The `multipleChoice` setting relies on the `choices`  (maximum number of choices that can be selected) value. The `choices` value `1` is `No Limit` on Crowdsignal. This was broken on both the poll defaults in settings and on individual polls. On poll settings, the default should always be `1` because we don't know the number of options a poll will have.

### Testing Instructions
- Go to Poll settings (either Settings > Polls or Crowdsignal > Poll Settings depending on the status of #31). 
- Toggle the `Multiple choice` default setting. Save. Make sure the state is saved by going back to Poll Settings and making sure the new option is saved.
- Create a new poll. Add some options. Check `Multiple choice` and leave it as `No Limit`. Make sure the setting is saved when clicking on `Save` and refreshing the page.

cc: @ice9js (Looks like some of the code on CS was last updated by you... don't want to mess up anything)