### PR TITLE
Add PR and issue templates to the repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,45 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: "bug"
+assignees: ''
+
+---
+
+<!-- Thanks for contributing to Crowdsignal! Pick a clear title ("Polls: Allow multiple choice as default setting") and proceed. -->
+
+#### Steps to Reproduce
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+#### What I Expected
+
+
+#### What Happened Instead
+
+
+#### PHP / WordPress / Crowdsignal version
+
+
+#### Browser / OS version
+
+
+#### Screenshot / Video
+
+
+#### Context / Source
+<!-- Optional: share your unique context to help us understand your perspective. -->
+
+
+
+<!--
+PLEASE NOTE
+- These comments won't show up when you submit the issue.
+- Everything is optional, but try to add as many details as possible.
+
+Helpful tips for screenshots:
+https://en.support.wordpress.com/make-a-screenshot/
+-->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: "enhancement"
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+Fixes #
+
+#### Changes proposed in this Pull Request:
+
+*
+
+#### Testing instructions:
+
+*
+
+<!--
+Helpful tips for screenshots:
+https://en.support.wordpress.com/make-a-screenshot/
+-->
+#### Screenshot / Video
+
+
+
+<!-- Add the following only if this is meant to be in changelog -->
+#### Proposed changelog entry for your changes:


### PR DESCRIPTION
The goal of this PR is to add templates for our issues and PRs, creating a standard and preventing us to forget any information when creating them. The templates were created based on what we have today on some repos.

This PR is a "replication" of this POC: https://github.com/Automattic/wp-job-manager-applications/pull/249

The issue that lists the repos that will receive the templates: https://github.com/Automattic/guardians/issues/540