### PR TITLE
Fix links to settings and unblock new setups

### DIFF
--- a/polldaddy-org.php
+++ b/polldaddy-org.php
@@ -642,7 +642,7 @@ function polldaddy_login_warning() {
 		return;
 	}
 
-	// We want the options page to load.
+	// We want the main poll options page to never show this message.
 	if ( 'polls' === $page && 'options' === $action ) {
 		return;
 	}

--- a/polldaddy-org.php
+++ b/polldaddy-org.php
@@ -133,7 +133,7 @@ class WPORG_Polldaddy extends WP_Polldaddy {
 
 		//need to set this to make sure that menus behave properly
 		if ( in_array( $action, array( 'options', 'update-rating' ) ) ) {
-			$parent_file  = 'options-general.php';
+			$parent_file  = 'admin.php';
 			$submenu_file = $page.'&action=options';
 		} else {
 			add_filter( 'admin_title', array( &$this, 'admin_title' ) );
@@ -629,10 +629,22 @@ if ( class_exists( 'PD_Top_Rated' ) ) {
 }
 
 function polldaddy_login_warning() {
-	global $cache_enabled, $hook_suffix;
-	$page = isset( $_GET[ 'page' ] ) ? $_GET[ 'page' ] : '';
-	if ( ( $hook_suffix == 'plugins.php' || $page == 'polls' ) && false == get_option( 'polldaddy_api_key' ) && function_exists( "admin_url" ) )
-		echo '<div class="updated"><p><strong>' . sprintf( __( 'Warning! The Crowdsignal plugin must be linked to your Crowdsignal.com account. Please visit the <a href="%s">plugin settings page</a> to login.', 'polldaddy' ), admin_url( 'options-general.php?page=polls&action=options' ) ) . '</strong></p></div>';
+	global $hook_suffix;
+
+	if (  false != get_option( 'polldaddy_api_key' ) || ! function_exists( "admin_url" ) ) {
+		return;
+	}
+
+	$page   = isset( $_GET['page'] ) ? $_GET['page'] : '';
+	$action = isset( $_GET['action'] ) ? $_GET['action'] : '';
+
+	if ( 'plugins.php' !== $hook_suffix && ! in_array( $page, [ 'polls', 'ratings' ], true ) ) {
+		return;
+	}
+
+	if ( 'options' !== $action ) {
+		echo '<div class="updated"><p><strong>' . sprintf( __( 'Warning! The Crowdsignal plugin must be linked to your Crowdsignal.com account. Please visit the <a href="%s">plugin settings page</a> to login.', 'polldaddy' ), admin_url( 'admin.php?page=polls&action=options' ) ) . '</strong></p></div>';
+	}
 }
 add_action( 'admin_notices', 'polldaddy_login_warning' );
 

--- a/polldaddy-org.php
+++ b/polldaddy-org.php
@@ -642,9 +642,12 @@ function polldaddy_login_warning() {
 		return;
 	}
 
-	if ( 'options' !== $action ) {
-		echo '<div class="updated"><p><strong>' . sprintf( __( 'Warning! The Crowdsignal plugin must be linked to your Crowdsignal.com account. Please visit the <a href="%s">plugin settings page</a> to login.', 'polldaddy' ), admin_url( 'admin.php?page=polls&action=options' ) ) . '</strong></p></div>';
+	// We want the options page to load.
+	if ( 'polls' === $page && 'options' === $action ) {
+		return;
 	}
+
+	echo '<div class="updated"><p><strong>' . sprintf( __( 'Warning! The Crowdsignal plugin must be linked to your Crowdsignal.com account. Please visit the <a href="%s">plugin settings page</a> to login.', 'polldaddy' ), admin_url( 'admin.php?page=polls&action=options' ) ) . '</strong></p></div>';
 }
 add_action( 'admin_notices', 'polldaddy_login_warning' );
 

--- a/polldaddy.php
+++ b/polldaddy.php
@@ -1473,10 +1473,12 @@ class WP_Polldaddy {
             return false;
 		$this->print_errors();
 		$polls = & $polls_object->poll;
-		if ( isset( $polls_object->_total ) )
+		$total_polls = 0;
+		if ( isset( $polls_object->_total ) ) {
 			$total_polls = $polls_object->_total;
-		else
+		} elseif ( ! empty( $polls ) ) {
 			$total_polls = count( $polls );
+		}
 		$class = '';
 
 		$page_links = paginate_links( array(

--- a/polldaddy.php
+++ b/polldaddy.php
@@ -416,13 +416,12 @@ class WP_Polldaddy {
 	}
 
 	function management_page_load() {
-
 		wp_reset_vars( array( 'page', 'action', 'poll', 'style', 'rating', 'id' ) );
 		global $plugin_page, $page, $action, $poll, $style, $rating, $id, $wp_locale;
 
 		$this->set_api_user_code();
 
-		if ( empty( $this->user_code ) && $page == 'polls' ) {
+		if ( empty( $this->user_code ) && $page == 'polls' && $action !== 'options' ) {
 			// one last try to get the user code automatically if possible
 			$this->user_code = apply_filters_ref_array( 'polldaddy_get_user_code', array( $this->user_code, &$this ) );
 			if ( false == $this->user_code && $action != 'restore-account' )
@@ -1412,7 +1411,7 @@ class WP_Polldaddy {
 ?>
 
 		<h2 id="poll-list-header"><?php
-				if ( $this->is_author )
+				if ( $this->is_author && defined( 'WP_POLLDADDY__PARTNERGUID' ) && WP_POLLDADDY__PARTNERGUID )
 					printf( __( 'Crowdsignal Polls <a href="%s" class="add-new-h2">Add New</a>', 'polldaddy' ), esc_url( add_query_arg( array( 'action' => 'create-poll', 'poll' => false, 'message' => false ) ) ) );
 				else
 					_e( 'Crowdsignal Polls ', 'polldaddy' );
@@ -1422,7 +1421,7 @@ class WP_Polldaddy {
 				if ( !empty( $account ) )
 					$account_email = esc_attr( $account->email );
 				if ( isset( $account_email ) && current_user_can( 'manage_options' ) ) {
-					echo "<p>" . sprintf( __( 'Linked to WordPress.com Account: <strong>%s</strong> (<a target="_blank" href="options-general.php?page=polls&action=options">Settings</a> / <a target="_blank" href="https://app.crowdsignal.com/">Crowdsignal.com</a>)', 'polldaddy' ), $account_email ) . "</p>";
+					echo "<p>" . sprintf( __( 'Linked to WordPress.com Account: <strong>%s</strong> (<a target="_blank" href="admin.php?page=polls&action=options">Settings</a> / <a target="_blank" href="https://app.crowdsignal.com/">Crowdsignal.com</a>)', 'polldaddy' ), $account_email ) . "</p>";
 				}
 
 				if ( !isset( $_GET['view'] ) )
@@ -4050,7 +4049,7 @@ src="https://static.polldaddy.com/p/<?php echo (int) $poll_id; ?>.js"&gt;&lt;/sc
 		$previous_settings = get_option( 'polldaddy_settings' );
 		$current_setting   = get_option( 'pd-rating-posts-id' );
 		if ( $current_setting && isset( $previous_settings[ 'pd-rating-posts-id' ] ) && $current_setting != $previous_settings[ 'pd-rating-posts-id' ] ) {
-			echo "<p>" . sprintf( __( "Previous settings for ratings on this site discovered. You can restore them on the <a href='%s'>poll settings page</a> if your site is missing ratings after resetting your connection settings.", 'polldaddy' ), "options-general.php?page=polls&action=options" ) . "</p>";
+			echo "<p>" . sprintf( __( "Previous settings for ratings on this site discovered. You can restore them on the <a href='%s'>poll settings page</a> if your site is missing ratings after resetting your connection settings.", 'polldaddy' ), "admin.php?page=polls&action=options" ) . "</p>";
 		}
 		?>
         </div>
@@ -4757,7 +4756,7 @@ src="https://static.polldaddy.com/p/<?php echo (int) $poll_id; ?>.js"&gt;&lt;/sc
 ?>
 		<div class="wrap">
 			<?php if ( $this->is_admin ) : ?>
-			<h2 id="polldaddy-header"><?php printf( __( 'Rating Results <a href="%s" class="add-new-h2">Settings</a>', 'polldaddy' ), esc_url( 'options-general.php?page=ratings&action=options' ) ); ?></h2>
+			<h2 id="polldaddy-header"><?php printf( __( 'Rating Results <a href="%s" class="add-new-h2">Settings</a>', 'polldaddy' ), esc_url( 'admin.php?page=ratings&action=options' ) ); ?></h2>
 			<?php else : ?>
 			<h2 id="polldaddy-header"><?php _e( 'Rating Results', 'polldaddy' ); ?></h2>
 			<?php endif; ?>
@@ -5268,7 +5267,7 @@ if ( false == is_object( $poll ) ) {
 		echo '<h1>' . $message . '</h1>';
 		echo '<p>' . __( "There are a few things you can do:" );
 		echo "<ul><ol>" . __( "Press reload on your browser and reload this page. There may have been a temporary problem communicating with Crowdsignal.com", "polldaddy" ) . "</ol>";
-		echo "<ol>" . sprintf( __( "Go to the <a href='%s'>poll settings page</a>, scroll to the end of the page and reset your connection settings. Link your account again with the same API key.", "polldaddy" ), 'options-general.php?page=polls&action=options' ) . "</ol>";
+		echo "<ol>" . sprintf( __( "Go to the <a href='%s'>poll settings page</a>, scroll to the end of the page and reset your connection settings. Link your account again with the same API key.", "polldaddy" ), 'admin.php?page=polls&action=options' ) . "</ol>";
 		echo "<ol>" . sprintf( __( 'Contact <a href="%1$s" %2$s>Crowdsignal support</a> and tell them your rating usercode is %3$s', 'polldaddy' ), 'https://crowdsignal.com/feedback/', 'target="_blank"', $this->rating_user_code ) . '<br />' . __( 'Also include the following information when contacting support to help us resolve your problem as quickly as possible:', 'polldaddy' ) . '';
 		echo "<ul><li> API Key: " . get_option( 'polldaddy_api_key' ) . "</li>";
 		echo "<li> ID Usercode: " . get_option( 'pd-usercode-' . $current_user->ID ) . "</li>";

--- a/polldaddy.php
+++ b/polldaddy.php
@@ -5200,7 +5200,12 @@ if ( false == is_object( $poll ) ) {
 		</form>
 		<br />
 		<?php
-		if ( $show_reset_form && isset( $settings[ 'pd-rating-posts-id' ] ) && $settings[ 'pd-rating-posts-id' ] != $previous_settings[ 'pd-rating-posts-id' ] ) {
+		if (
+			$show_reset_form
+			&& isset( $settings[ 'pd-rating-posts-id' ] )
+			&& isset( $previous_settings[ 'pd-rating-posts-id' ] )
+			&& $settings[ 'pd-rating-posts-id' ] != $previous_settings[ 'pd-rating-posts-id' ]
+		) {
 			echo "<h3>" . __( 'Restore Ratings Settings', 'polldaddy' ) . "</h3>";
 			echo "<p>" . __( 'Different rating settings detected. If you are missing ratings on your posts, pages or comments you can restore the original rating settings by clicking the button below.', 'polldaddy' ) . "</p>";
 			echo "<p>" . __( 'This tells the plugin to look for this data in a different rating in your Crowdsignal account.', 'polldaddy' ) . "</p>";


### PR DESCRIPTION
In testing, I found a regression caused by the move of the settings pages. This fixes that issue plus a few more.

### Changes Proposed 
- Fix issue where links to set up account would point to the old `options-general.php` endpoint. This _would_ work, but the menu bar goes wonky. To fix this, I also had to fix some checks to allow options to load when the key hadn't been set yet.
- Fix issue where `Add New` button shows up when viewing polls without an API key.
- Fix `count()` error that @roundhill found during testing on Polls page.

### Testing
- Start from a fresh install.
- Activate plugin.
- First browse around. Verify links to set up plugin point to page that (a) loads; (b) activates the Crowdsignal menu item.
- Verify buttons to things that shouldn't show up don't show up when disconnected from API.
- Activate API key.
- Make sure things still work.

