### PR TITLE
Update wp_parse_str to match upstream function

### DIFF
--- a/polldaddy-client.php
+++ b/polldaddy-client.php
@@ -1323,21 +1323,14 @@ if ( !function_exists( 'wp_parse_str' ) ) :
 /**
  * Parses a string into variables to be stored in an array.
  *
- * Uses {@link http://www.php.net/parse_str parse_str()} and stripslashes if
- * {@link http://www.php.net/magic_quotes magic_quotes_gpc} is on.
- *
  * @since 2.2.1
  * @uses apply_filters() for the 'wp_parse_str' filter.
  *
  * @param string $string The string to be parsed.
- * @param array $array Variables will be stored in this array.
+ * @param array  $array Variables will be stored in this array.
  */
 function wp_parse_str( $string, &$array ) {
 	parse_str( $string, $array );
-	if ( get_magic_quotes_gpc() )
-		$array = stripslashes_deep( $array );
-	return $array;
-
 	$array = apply_filters( 'wp_parse_str', $array );
 }
 endif;


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request:

* Sync the [`wp_parse_str`](https://developer.wordpress.org/reference/functions/wp_parse_str/) shiv to match the current iteration of the function from core. This removes a call to [`get_magic_quotes_gpc`](https://www.php.net/manual/en/function.get-magic-quotes-gpc.php) which is deprecated in PHP 7.4 and has always returned `false` since PHP 5.4. The way the current shiv was working was also terminating the function prematurely, preventing the `wp_parse_str` filter from ever working.

#### Testing instructions:

* This change mimics how WordPress core has worked since 5.3

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
#### Screenshot / Video



<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
