### PR TITLE
AMP Support For Polls & Surveys

### DIFF
--- a/polldaddy-shortcode.php
+++ b/polldaddy-shortcode.php
@@ -118,6 +118,8 @@ CONTAINER;
 
 		self::$add_script = $infinite_scroll;
 
+		$is_amp = function_exists( 'is_amp_endpoint' ) && is_amp_endpoint();
+
 		if ( intval( $rating ) > 0 && !$no_script ) { //rating embed
 
 			if ( empty( $unique_id ) )
@@ -177,6 +179,10 @@ CONTAINER;
 CONTAINER;
 			}
 		} elseif ( intval( $poll ) > 0 ) { //poll embed
+
+			if ( $is_amp ) {
+				return sprintf( '<amp-iframe src="https://poll.fm/%d/embed" frameborder="0" height="400" layout="fixed-height" width="auto" sandbox="allow-scripts allow-same-origin" style="height: 400px; --loader-delay-offset:406ms !important;" i-amphtml-layout="fixed-height"></amp-iframe>', $poll );
+			}
 
 			$poll      = intval( $poll );
 			$poll_url  = sprintf( 'https://poll.fm/%d', $poll );

--- a/polldaddy-shortcode.php
+++ b/polldaddy-shortcode.php
@@ -443,6 +443,10 @@ new PolldaddyShortcode();
 if ( !function_exists( 'polldaddy_link' ) ) {
 	// http://polldaddy.com/poll/1562975/?view=results&msg=voted
 	function polldaddy_link( $content ) {
+		if ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() ) {
+			return $content;
+		}
+
 		if ( false === strpos( $content, "polldaddy.com/" ) )
 			return $content;
 		$textarr = wp_html_split( $content );

--- a/polldaddy-shortcode.php
+++ b/polldaddy-shortcode.php
@@ -499,7 +499,7 @@ if ( !function_exists( 'polldaddy_link' ) ) {
 				$poll_embed_markup = cs_render_poll_amp_iframe( "$2" );
 
 				// if survey link is found, replace it with amp.
-				$element = preg_replace( '!(?:\n|\A)https?://([0-9a-zA-Z\-]+)\.survey\.fm/([0-9a-zA-Z\-]+?)(/.*)?(?:\n|\Z)!i', cs_render_survey_amp_iframe_from_user_slug( "$1", "$2"), $element );
+				$element = preg_replace( '!(?:\n|\A)https?://([0-9a-zA-Z\-_]+)\.survey\.fm/([0-9a-zA-Z\-]+?)(/.*)?(?:\n|\Z)!i', cs_render_survey_amp_iframe_from_user_slug( "$1", "$2"), $element );
 			}
 
 			// if poll link is found, replace it with poll embed

--- a/polldaddy-shortcode.php
+++ b/polldaddy-shortcode.php
@@ -288,8 +288,13 @@ CONTAINER;
 				if ( $type == 'banner' || $type == 'slider' )
 					$inline = false;
 
-				$survey      = preg_replace( '/[^a-f0-9]/i', '', $survey );
-				$survey_url  = esc_url( "https://survey.fm/{$survey}" );
+				$survey     = preg_replace( '/[^a-f0-9]/i', '', $survey );
+				$survey_url = esc_url( "https://survey.fm/{$survey}" );
+
+				if ( 'iframe' === $type && cs_is_amp_page() ) {
+					return cs_render_survey_amp_iframe( $survey_url );
+				}
+
 				$survey_link = sprintf( '<a href="%s">%s</a>', $survey_url, esc_html( $title ) );
 
 				if ( $no_script || $inline || $infinite_scroll )
@@ -463,6 +468,15 @@ if ( !function_exists( 'cs_is_amp_page' ) ) {
 	function cs_render_poll_amp_iframe( $poll_id ) {
 		return sprintf( "<amp-iframe resizable class='cs-iframe-embed' src='https://poll.fm/%s/embed' frameborder='0' height='400' layout='fixed-height' width='auto' sandbox='allow-scripts allow-same-origin' style='height: 400px; --loader-delay-offset:406ms !important;' i-amphtml-layout='fixed-height'><span overflow placeholder='' class='amp-wp-iframe-placeholder'></span><noscript><iframe src='https://poll.fm/%s/embed' frameborder='0' class='cs-iframe-embed'></iframe></noscript></amp-iframe>", $poll_id, $poll_id );
 	}
+
+	function cs_render_survey_amp_iframe_from_user_slug( $user, $slug ) {
+		return cs_render_survey_amp_iframe( sprintf( 'https://%s.survey.fm/%s', $user, $slug ) );
+	}
+
+	function cs_render_survey_amp_iframe( $survey_url ) {
+		$iframe_survey_url = $survey_url . '?iframe=1';
+		return sprintf( "<amp-iframe resizable class='cs-iframe-embed' src='%s' frameborder='0' height='400' layout='fixed-height' width='auto' sandbox='allow-scripts allow-same-origin' style='height: 400px; --loader-delay-offset:406ms !important;' i-amphtml-layout='fixed-height'><span overflow placeholder='' class='amp-wp-iframe-placeholder'></span><noscript><iframe src='%s' frameborder='0' class='cs-iframe-embed'></iframe></noscript></amp-iframe>", $iframe_survey_url, $iframe_survey_url );
+	}
 }
 
 if ( !function_exists( 'polldaddy_link' ) ) {
@@ -479,13 +493,17 @@ if ( !function_exists( 'polldaddy_link' ) ) {
 				continue;
 			}
 
-			$embed_markup = "\n<script type='text/javascript' charset='utf-8' src='//static.polldaddy.com/p/$2.js'></script><noscript> <a href='https://poll.fm/$2'>View Poll</a></noscript>\n";
+			$poll_embed_markup = "\n<script type='text/javascript' charset='utf-8' src='//static.polldaddy.com/p/$2.js'></script><noscript> <a href='https://poll.fm/$2'>View Poll</a></noscript>\n";
 
 			if ( cs_is_amp_page() ) {
-				$embed_markup = cs_render_poll_amp_iframe( "$2" );
+				$poll_embed_markup = cs_render_poll_amp_iframe( "$2" );
+
+				// if survey link is found, replace it with amp.
+				$element = preg_replace( '!(?:\n|\A)https?://([0-9a-zA-Z\-]+)\.survey\.fm/([0-9a-zA-Z\-]+?)(/.*)?(?:\n|\Z)!i', cs_render_survey_amp_iframe_from_user_slug( "$1", "$2"), $element );
 			}
 
-			$element = preg_replace( '!(?:\n|\A)https?://(polldaddy\.com/poll|poll\.fm)/([0-9]+?)(/.*)?(?:\n|\Z)!i', $embed_markup, $element );
+			// if poll link is found, replace it with poll embed
+			$element = preg_replace( '!(?:\n|\A)https?://(polldaddy\.com/poll|poll\.fm)/([0-9]+?)(/.*)?(?:\n|\Z)!i', $poll_embed_markup, $element );
 		}
 		return join( $textarr );
 	}

--- a/polldaddy-shortcode.php
+++ b/polldaddy-shortcode.php
@@ -475,7 +475,7 @@ if ( !function_exists( 'cs_is_amp_page' ) ) {
 
 	function cs_render_survey_amp_iframe( $survey_url ) {
 		$iframe_survey_url = $survey_url . '?iframe=1';
-		return sprintf( "<amp-iframe resizable class='cs-iframe-embed' src='%s' frameborder='0' height='400' layout='fixed-height' width='auto' sandbox='allow-scripts allow-same-origin' style='height: 400px; --loader-delay-offset:406ms !important;' i-amphtml-layout='fixed-height'><span overflow placeholder='' class='amp-wp-iframe-placeholder'></span><noscript><iframe src='%s' frameborder='0' class='cs-iframe-embed'></iframe></noscript></amp-iframe>", $iframe_survey_url, $iframe_survey_url );
+		return sprintf( "<amp-iframe resizable class='cs-iframe-embed' src='%s' frameborder='0' height='400' layout='fixed-height' width='auto' sandbox='allow-scripts allow-same-origin allow-forms' style='height: 400px; --loader-delay-offset:406ms !important;' i-amphtml-layout='fixed-height'><span overflow placeholder='' class='amp-wp-iframe-placeholder'></span><noscript><iframe src='%s' frameborder='0' class='cs-iframe-embed'></iframe></noscript></amp-iframe>", $iframe_survey_url, $iframe_survey_url );
 	}
 }
 

--- a/polldaddy-shortcode.php
+++ b/polldaddy-shortcode.php
@@ -118,8 +118,6 @@ CONTAINER;
 
 		self::$add_script = $infinite_scroll;
 
-		$is_amp = function_exists( 'is_amp_endpoint' ) && is_amp_endpoint();
-
 		if ( intval( $rating ) > 0 && !$no_script ) { //rating embed
 
 			if ( empty( $unique_id ) )
@@ -180,7 +178,7 @@ CONTAINER;
 			}
 		} elseif ( intval( $poll ) > 0 ) { //poll embed
 
-			if ( $is_amp ) {
+			if ( cs_is_amp_page() ) {
 				return sprintf( '<amp-iframe src="https://poll.fm/%d/embed" frameborder="0" height="400" layout="fixed-height" width="auto" sandbox="allow-scripts allow-same-origin" style="height: 400px; --loader-delay-offset:406ms !important;" i-amphtml-layout="fixed-height"></amp-iframe>', $poll );
 			}
 
@@ -446,10 +444,27 @@ SCRIPT;
 // kick it all off
 new PolldaddyShortcode();
 
+if ( !function_exists( 'cs_is_amp_page' ) ) {
+
+	// Check for existance of top 2 AMP plugin endpoints
+	function cs_is_amp_page() {
+
+		if ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() ) {
+			return true;
+		}
+
+		if ( function_exists( 'ampforwp_is_amp_endpoint' ) && ampforwp_is_amp_endpoint() ) {
+			return true;
+		}
+
+		return false;
+	}
+}
+
 if ( !function_exists( 'polldaddy_link' ) ) {
 	// http://polldaddy.com/poll/1562975/?view=results&msg=voted
 	function polldaddy_link( $content ) {
-		if ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() ) {
+		if ( cs_is_amp_page() ) {
 			return $content;
 		}
 


### PR DESCRIPTION
This PR replaces poll js embed rendering with an amp-iframe when the page is being served via AMP.

#### Changes proposed in this Pull Request:

* convert crowdsignal poll shortcode and oembeds to an `amp-iframe` instead of a poll js embed (markup taken from what WordPress renders by default, with some changes to support iframe resizing)

#### Testing instructions:
The Official AMP plugin needs to be installed on your site (or test on WPCOM) OR `AMP for WP – Accelerated Mobile Pages` plugin

1. Add a Poll embed to a post (paste a poll url in an `/embed` block, or just in a new line on the page)
2. Add a Poll shortcode to a post `[crowdsignal poll=10603231]`
3. View the public post using the `/amp` endpoint and the poll should render correctly (as an iframe)
4. View the public post NOT using the `/amp` endpoint and the poll should render correctly (as a js embed)

**Known issues**
- if the amp-iframe is too close to the top of the page, it isn't allowed to render (an AMP rule, you will see an error stating this in the console if it happens)
- if there are a lot of amp-iframes on a page they may not all resize 🤷 

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes: