### PR TITLE
Fix menu items so they don't mess up the Jetpack Feedback menu

### DIFF
--- a/polldaddy-org.php
+++ b/polldaddy-org.php
@@ -82,7 +82,7 @@ class WPORG_Polldaddy extends WP_Polldaddy {
 
 		$this->set_api_user_code();
 
-		if ( $page == 'polls' ) {
+		if ( 'polls' === $page || 'pollsettings' === $page ) {
 			switch ( $action ) {
 			case 'update-options' :
 				if ( !$is_POST )

--- a/polldaddy.php
+++ b/polldaddy.php
@@ -84,6 +84,46 @@ class WP_Polldaddy {
 
 			add_filter( 'jetpack_options_whitelist', array( $this, 'add_to_jetpack_options_whitelist' ) );
 		}
+
+		if ( ! post_type_exists( 'feedback' ) ) {
+			register_post_type(
+				'feedback', array(
+					'labels'                => array(
+					),
+					'menu_icon'             => 'dashicons-feedback',
+					'show_ui'               => true,
+					'show_in_menu'          => 'edit.php?post_type=feedback',
+					'show_in_admin_bar'     => false,
+					'public'                => false,
+					'rewrite'               => false,
+					'query_var'             => false,
+					'capability_type'       => 'page',
+					'show_in_rest'          => true,
+					'rest_controller_class' => 'Grunion_Contact_Form_Endpoint',
+					'capabilities'          => array(
+						'create_posts'        => 'do_not_allow',
+						'publish_posts'       => 'publish_pages',
+						'edit_posts'          => 'edit_pages',
+						'edit_others_posts'   => 'edit_others_pages',
+						'delete_posts'        => 'delete_pages',
+						'delete_others_posts' => 'delete_others_pages',
+						'read_private_posts'  => 'read_private_pages',
+						'edit_post'           => 'edit_page',
+						'delete_post'         => 'delete_page',
+						'read_post'           => 'read_page',
+					),
+					'map_meta_cap'          => true,
+				)
+			);
+			add_action( 'admin_menu', array( $this, 'remove_feedback_menu' ) );
+		}
+	}
+
+   /**
+	* Remove the feedback submenu if not needed.
+	*/
+	public function remove_feedback_menu() {
+		remove_submenu_page( 'edit.php?post_type=feedback', 'edit.php?post_type=feedback' );
 	}
 
    /**

--- a/polldaddy.php
+++ b/polldaddy.php
@@ -120,7 +120,7 @@ class WP_Polldaddy {
 	}
 
    /**
-	* Remove the feedback submenu if not needed.
+	* Remove the feedback "All Posts" submenu if not needed.
 	*/
 	public function remove_feedback_menu() {
 		remove_submenu_page( 'edit.php?post_type=feedback', 'edit.php?post_type=feedback' );

--- a/polldaddy.php
+++ b/polldaddy.php
@@ -449,7 +449,7 @@ class WP_Polldaddy {
 			}
 			$plugin_page = 'ratings&action=reports';
 		} elseif ( $page == 'ratingsettings' ) {
-			$plugin_page = 'ratings&action=options';
+			$plugin_page = 'ratingsettings';
 			wp_enqueue_script( 'rating-text-color', "{$this->base_url}js/jscolor.js", array(), $this->version );
 			wp_enqueue_script( 'ratings', "{$this->base_url}js/rating.js", array(), $this->version );
 			wp_localize_script( 'polls-common', 'adminRatingsL10n', array(
@@ -1414,7 +1414,7 @@ class WP_Polldaddy {
 				if ( !empty( $account ) )
 					$account_email = esc_attr( $account->email );
 				if ( isset( $account_email ) && current_user_can( 'manage_options' ) ) {
-					echo "<p>" . sprintf( __( 'Linked to WordPress.com Account: <strong>%s</strong> (<a target="_blank" href="admin.php?page=polls&action=options">Settings</a> / <a target="_blank" href="https://app.crowdsignal.com/">Crowdsignal.com</a>)', 'polldaddy' ), $account_email ) . "</p>";
+					echo "<p>" . sprintf( __( 'Linked to WordPress.com Account: <strong>%1$s</strong> (<a target="_blank" href="%2$s">Settings</a> / <a target="_blank" href="%3$s">Crowdsignal.com</a>)', 'polldaddy' ), $account_email, admin_url( 'options-general.php?page=pollsettings' ), 'https://app.crowdsignal.com/' ) . "</p>";
 				}
 
 				if ( !isset( $_GET['view'] ) )
@@ -4038,7 +4038,7 @@ src="https://static.polldaddy.com/p/<?php echo (int) $poll_id; ?>.js"&gt;&lt;/sc
 		$previous_settings = get_option( 'polldaddy_settings' );
 		$current_setting   = get_option( 'pd-rating-posts-id' );
 		if ( $current_setting && isset( $previous_settings[ 'pd-rating-posts-id' ] ) && $current_setting != $previous_settings[ 'pd-rating-posts-id' ] ) {
-			echo "<p>" . sprintf( __( "Previous settings for ratings on this site discovered. You can restore them on the <a href='%s'>poll settings page</a> if your site is missing ratings after resetting your connection settings.", 'polldaddy' ), "admin.php?page=polls&action=options" ) . "</p>";
+			echo "<p>" . sprintf( __( "Previous settings for ratings on this site discovered. You can restore them on the <a href='%s'>poll settings page</a> if your site is missing ratings after resetting your connection settings.", 'polldaddy' ), "options-general.php?page=pollsettings" ) . "</p>";
 		}
 		?>
         </div>
@@ -4745,7 +4745,7 @@ src="https://static.polldaddy.com/p/<?php echo (int) $poll_id; ?>.js"&gt;&lt;/sc
 ?>
 		<div class="wrap">
 			<?php if ( $this->is_admin ) : ?>
-			<h2 id="polldaddy-header"><?php printf( __( 'Rating Results <a href="%s" class="add-new-h2">Settings</a>', 'polldaddy' ), esc_url( 'admin.php?page=ratings&action=options' ) ); ?></h2>
+			<h2 id="polldaddy-header"><?php printf( __( 'Rating Results <a href="%s" class="add-new-h2">Settings</a>', 'polldaddy' ), esc_url( 'options-general.php?page=ratingsettings' ) ); ?></h2>
 			<?php else : ?>
 			<h2 id="polldaddy-header"><?php _e( 'Rating Results', 'polldaddy' ); ?></h2>
 			<?php endif; ?>
@@ -5261,7 +5261,7 @@ if ( false == is_object( $poll ) ) {
 		echo '<h1>' . $message . '</h1>';
 		echo '<p>' . __( "There are a few things you can do:" );
 		echo "<ul><ol>" . __( "Press reload on your browser and reload this page. There may have been a temporary problem communicating with Crowdsignal.com", "polldaddy" ) . "</ol>";
-		echo "<ol>" . sprintf( __( "Go to the <a href='%s'>poll settings page</a>, scroll to the end of the page and reset your connection settings. Link your account again with the same API key.", "polldaddy" ), 'admin.php?page=polls&action=options' ) . "</ol>";
+		echo "<ol>" . sprintf( __( "Go to the <a href='%s'>poll settings page</a>, scroll to the end of the page and reset your connection settings. Link your account again with the same API key.", "polldaddy" ), 'options-general.php?page=pollsettings' ) . "</ol>";
 		echo "<ol>" . sprintf( __( 'Contact <a href="%1$s" %2$s>Crowdsignal support</a> and tell them your rating usercode is %3$s', 'polldaddy' ), 'https://crowdsignal.com/feedback/', 'target="_blank"', $this->rating_user_code ) . '<br />' . __( 'Also include the following information when contacting support to help us resolve your problem as quickly as possible:', 'polldaddy' ) . '';
 		echo "<ul><li> API Key: " . get_option( 'polldaddy_api_key' ) . "</li>";
 		echo "<li> ID Usercode: " . get_option( 'pd-usercode-' . $current_user->ID ) . "</li>";

--- a/polldaddy.php
+++ b/polldaddy.php
@@ -130,39 +130,33 @@ class WP_Polldaddy {
 
 		$icon_encoded = 'PHN2ZyBpZD0iY29udGVudCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2aWV3Qm94PSIwIDAgMjg4IDIyMCI+PGRlZnM+PHN0eWxlPi5jbHMtMXtmaWxsOiNGRkZGRkY7fTwvc3R5bGU+PC9kZWZzPjx0aXRsZT5pY29uLWJsdWU8L3RpdGxlPjxwYXRoIGNsYXNzPSJjbHMtMSIgZD0iTTI2Mi40MSw4MC4xYy04LjQ3LTIyLjU1LTE5LjA1LTQyLjgzLTI5Ljc5LTU3LjFDMjIwLjc0LDcuMjQsMjEwLC41NywyMDEuNDcsMy43OWExMi4zMiwxMi4zMiwwLDAsMC0zLjcyLDIuM2wtLjA1LS4xNUwxNiwxNzMuOTRsOC4yLDE5LjEyLDMwLjU2LTEuOTJ2MTMuMDVhMTIuNTcsMTIuNTcsMCwwLDAsMTIuNTgsMTIuNTZjLjMzLDAsLjY3LDAsMSwwbDU4Ljg1LTQuNzdhMTIuNjUsMTIuNjUsMCwwLDAsMTEuNTYtMTIuNTNWMTg1Ljg2bDEyMS40NS03LjY0YTEzLjg4LDEzLjg4LDAsMCwwLDIuMDkuMjYsMTIuMywxMi4zLDAsMCwwLDQuNDEtLjhDMjg1LjMzLDE3MC43LDI3OC42MywxMjMuMzEsMjYyLjQxLDgwLjFabS0yLjI2LDg5Ljc3Yy0xMC40OC0zLjI1LTMwLjQ0LTI4LjE1LTQ2LjY4LTcxLjM5LTE1LjcyLTQxLjktMTcuNS03My4yMS0xMi4zNC04My41NGE2LjUyLDYuNTIsMCwwLDEsMy4yMi0zLjQ4LDMuODIsMy44MiwwLDAsMSwxLjQxLS4yNGMzLjg1LDAsMTAuOTQsNC4yNiwyMC4zMSwxNi43MUMyMzYuMzYsNDEuNTksMjQ2LjU0LDYxLjE1LDI1NC43NCw4M2MxOC40NCw0OS4xMiwxNy43NCw4My43OSw5LjEzLDg3QTUuOTMsNS45MywwLDAsMSwyNjAuMTUsMTY5Ljg3Wk0xMzAuNiwxOTkuNDFhNC40LDQuNCwwLDAsMS00LDQuMzdsLTU4Ljg1LDQuNzdBNC4zOSw0LjM5LDAsMCwxLDYzLDIwNC4xOVYxOTAuNjJsNjcuNjEtNC4yNVoiLz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik02LDE4NS4yNmExMC4yNSwxMC4yNSwwLDAsMCwxMC4yNSwxMC4yNSwxMC4wNSwxMC4wNSwwLDAsMCw0LjM0LTFsLTcuOTQtMTguNzNBMTAuMiwxMC4yLDAsMCwwLDYsMTg1LjI2WiIvPjwvc3ZnPgo=';
 
-		$hook = add_menu_page(
-			__( 'Crowdsignal', 'polldaddy' ),
-			__( 'Crowdsignal', 'polldaddy' ),
-			$capability,
-			'feedback',
-			$function,
-			'data:image/svg+xml;base64,' . $icon_encoded
-		);
-		add_action( "load-$hook", array( &$this, 'management_page_load' ) );
+		$slug = 'edit.php?post_type=feedback';
+
+		if ( ! $this->has_feedback_menu ) {
+			$hook = add_menu_page(
+				__( 'Feedback', 'polldaddy' ),
+				__( 'Feedback', 'polldaddy' ),
+				$capability,
+				$slug,
+				$function,
+				'data:image/svg+xml;base64,' . $icon_encoded
+			);
+			add_action( "load-$hook", array( &$this, 'management_page_load' ) );
+		}
 
 		foreach( array( 'polls' => __( 'Polls', 'polldaddy' ), 'ratings' => __( 'Ratings', 'polldaddy' ) ) as $menu_slug => $page_title ) {
 			$menu_title  = $page_title;
 
-			$hook = add_menu_page( $menu_title, $menu_title, $capability, $menu_slug, $function, 'div' );
+			$hook = add_submenu_page( $slug, $menu_title, $menu_title, $capability, $menu_slug, $function, 'div' );
 			add_action( "load-$hook", array( &$this, 'management_page_load' ) );
-
-			add_submenu_page( 'feedback', $page_title, $page_title, $capability, $menu_slug, $function );
 		}
 
 		// Add settings pages.
-		foreach( array( 'polls' => __( 'Poll', 'polldaddy' ), 'ratings' => __( 'Rating', 'polldaddy' ) ) as $menu_slug => $page_title ) {
+		foreach( array( 'pollsettings' => __( 'Poll', 'polldaddy' ), 'ratingsettings' => __( 'Rating', 'polldaddy' ) ) as $menu_slug => $page_title ) {
 			// translators: %s placeholder is the setting page type (Poll or Rating).
 			$settings_page_title = sprintf( esc_html__( '%s Settings', 'polldaddy' ), $page_title );
-			add_submenu_page( 'feedback', $settings_page_title, $settings_page_title, $menu_slug == 'ratings' ? 'manage_options' : $capability, $menu_slug.'&action=options', $function );
-		}
-
-		remove_submenu_page( 'feedback', 'feedback' );
-		remove_menu_page( 'polls' );
-		remove_menu_page( 'ratings' );
-
-		if ( $this->has_feedback_menu ) {
-			add_submenu_page( 'feedback', __( 'Feedback', 'polldaddy' ), __( 'Feedback', 'polldaddy' ), 'edit_posts', 'edit.php?post_type=feedback' );
-			remove_menu_page( 'edit.php?post_type=feedback' );
+			$hook = add_options_page( $settings_page_title, $settings_page_title, $menu_slug == 'ratings' ? 'manage_options' : $capability, $menu_slug, array( $this, 'settings_page' ) );
+			add_action( "load-$hook", array( $this, 'management_page_load' ) );
 		}
 
 		add_action( 'media_buttons', array( &$this, 'media_buttons' ) );
@@ -407,7 +401,7 @@ class WP_Polldaddy {
 
 		$this->set_api_user_code();
 
-		if ( empty( $this->user_code ) && $page == 'polls' && $action !== 'options' ) {
+		if ( empty( $this->user_code ) && 'pollsettings' === $page && 'options' !== $action ) {
 			// one last try to get the user code automatically if possible
 			$this->user_code = apply_filters_ref_array( 'polldaddy_get_user_code', array( $this->user_code, &$this ) );
 			if ( false == $this->user_code && $action != 'restore-account' )
@@ -446,30 +440,21 @@ class WP_Polldaddy {
 			case 'list-styles' :
 				$plugin_page = 'polls&action=list-styles';
 				break;
-			case 'options' :
-			case 'update-options' :
-			case 'import-account' :
-			case 'reset-account' :
-			case 'restore-account' :
-				$plugin_page = 'polls&action=options';
-				break;
 			}//end switch
+		} elseif ( $page == 'pollsettings' ) {
+			$plugin_page = 'pollsettings';
 		} elseif ( $page == 'ratings' ) {
-			switch ( $action ) {
-			case 'update-rating' :
-			case 'options':
-				$plugin_page = 'ratings&action=options';
-				wp_enqueue_script( 'rating-text-color', "{$this->base_url}js/jscolor.js", array(), $this->version );
-				wp_enqueue_script( 'ratings', "{$this->base_url}js/rating.js", array(), $this->version );
-				wp_localize_script( 'polls-common', 'adminRatingsL10n', array(
-						'star_colors' => __( 'Star Colors', 'polldaddy' ), 'star_size' =>  __( 'Star Size', 'polldaddy' ),
-						'nero_type' => __( 'Nero Type', 'polldaddy' ), 'nero_size' => __( 'Nero Size', 'polldaddy' ), ) );
-				break;
-			default :
-				if ( empty( $action ) )
-					$action = 'reports';
-				$plugin_page = 'ratings&action=reports';
-			}//end switch
+			if ( empty( $action ) ) {
+				$action = 'reports';
+			}
+			$plugin_page = 'ratings&action=reports';
+		} elseif ( $page == 'ratingsettings' ) {
+			$plugin_page = 'ratings&action=options';
+			wp_enqueue_script( 'rating-text-color', "{$this->base_url}js/jscolor.js", array(), $this->version );
+			wp_enqueue_script( 'ratings', "{$this->base_url}js/rating.js", array(), $this->version );
+			wp_localize_script( 'polls-common', 'adminRatingsL10n', array(
+				'star_colors' => __( 'Star Colors', 'polldaddy' ), 'star_size' =>  __( 'Star Size', 'polldaddy' ),
+				'nero_type' => __( 'Nero Type', 'polldaddy' ), 'nero_size' => __( 'Nero Size', 'polldaddy' ), ) );
 		}
 
 		wp_enqueue_style( 'polldaddy', "{$this->base_url}css/polldaddy.css", array(), $this->version );
@@ -519,7 +504,7 @@ class WP_Polldaddy {
 
 		$is_POST = 'post' == strtolower( $_SERVER['REQUEST_METHOD'] );
 
-		if ( $page == 'polls' ) {
+		if ( 'polls' === $page || 'pollsettings' === $page ) {
 			switch ( $action ) {
 			case 'reset-account' : // reset everything
 				global $current_user;
@@ -1128,7 +1113,7 @@ class WP_Polldaddy {
 			default :
 				return;
 			}//end switch
-		} elseif ( $page == 'ratings' ) {
+		} elseif ( 'ratings' === $page || 'ratingsettings' === $page ) {
 
 			switch ( $action ) {
 			case 'delete' :
@@ -1304,6 +1289,33 @@ class WP_Polldaddy {
 		$this->print_errors();
 	}
 
+	function settings_page() {
+		global $page, $action;
+?>
+	<div class="wrap" id="manage-polls">
+<?php
+		$this->set_api_user_code();
+
+		if ( isset( $_GET['page'] ) ) {
+			$page = $_GET['page'];
+		}
+		if ( 'pollsettings' === $page ) {
+			if ( ! $this->is_author ) { //check user privileges has access to action
+				return;
+			}
+			$this->plugin_options();
+		} elseif ( 'ratingsettings' === $page ) {
+			if ( 'update-rating' === $action ) {
+				$this->update_rating();
+			}
+
+			$this->rating_settings();
+		}
+?>
+	</div>
+<?php
+	}
+
 	function management_page() {
 
 		global $page, $action, $poll, $style, $rating;
@@ -1316,7 +1328,7 @@ class WP_Polldaddy {
 
 <?php
 		if ( $page == 'polls' ) {
-			if ( !$this->is_author && in_array( $action, array( 'edit', 'edit-poll', 'create-poll', 'edit-style', 'create-style', 'list-styles', 'options', 'update-options', 'import-account' ) ) ) {//check user privileges has access to action
+			if ( ! $this->is_author && in_array( $action, array( 'edit', 'edit-poll', 'create-poll', 'edit-style', 'create-style', 'list-styles' ) ) ) {//check user privileges has access to action
 				$action = '';
 			}
 			switch ( $action ) {
@@ -1387,11 +1399,6 @@ class WP_Polldaddy {
 <?php
 				$this->style_edit_form();
 				break;
-			case 'options' :
-			case 'import-account' :
-			case 'update-options' :
-				$this->plugin_options();
-				break;
 			default :
 
 ?>
@@ -1426,12 +1433,6 @@ class WP_Polldaddy {
 			case 'reports' :
 				$this->rating_reports();
 				break;
-			case 'update-rating' :
-				$this->update_rating();
-				$this->rating_settings();
-				break;
-			default :
-				$this->rating_settings();
 			}//end switch
 		}
 ?>
@@ -4068,7 +4069,7 @@ src="https://static.polldaddy.com/p/<?php echo (int) $poll_id; ?>.js"&gt;&lt;/sc
 			    <div class="inside">
 			        <div class="submitbox" id="submitpost">
 			            <div id="minor-publishing" style="padding:10px;">
-			                <input type="submit" name="save_menu" id="save_menu_header" class="button button-primary menu-save" value="<?php echo esc_attr( __( 'Save Changes', 'polldaddy' ) );?>">
+			                <input type="submit" name="save_menu" class="button button-primary menu-save" value="<?php echo esc_attr( __( 'Save Changes', 'polldaddy' ) );?>">
 			                <input type="hidden" name="type" value="<?php echo $report_type; ?>" />
 							<input type="hidden" name="rating_id" value="<?php echo $rating_id; ?>" />
 							<input type="hidden" name="action" value="update-rating" />


### PR DESCRIPTION
If Jetpack isn't installed then create a Feedback menu.
Put the reports in the Feedback menu.
Settings pages go in the Settings menu.
Don't move the Feedback menu as it is used by Jetpack for other things.

#### Testing instructions:

Apply patch.
Check the Feedback and Settings menus have the right reports and settings pages.

Change settings.
Create polls.

