### PR TITLE
Remove "poll owner is part of blog" check.

### DIFF
--- a/polldaddy.php
+++ b/polldaddy.php
@@ -5237,15 +5237,6 @@ if ( false == is_object( $poll ) ) {
 			return true;
 		}
 
-		//check to see if poll owner is a member of this blog
-		if ( function_exists( 'get_users' ) ) {
-			$user = get_users( array( 'include' => $poll->_owner ) );
-			if ( empty( $user ) ) {
-				$this->log( 'can_edit: poll owner is not a member of this blog.' );
-				return false;
-			}
-		}
-
 		if ( false == (bool) current_user_can( 'edit_others_posts' ) )
 			$this->log( 'can_edit: current user cannot edit_others_posts.' );
 


### PR DESCRIPTION
The poll owner isn't always set correctly so we shouldn't check if that user_id is a member of the current blog. It's enough that the local user has "edit_others_posts" capabilities.

Fixes #19 

To test:
Create a new API key in https://app.crowdsignal.com/account and connect on your blog using a test account. Uncheck the multiple user option on that page.
Create a poll with that user.
Switch to another user and delete the test user.
Load up Feedback->Polls and the poll created by the test user should only have the Preview link.

Apply patch and Edit and other links should appear.