### PR TITLE
add suggested edit from .org forum

### DIFF
--- a/polldaddy.php
+++ b/polldaddy.php
@@ -187,7 +187,7 @@ class WP_Polldaddy {
 		foreach( array( 'polls' => __( 'Polls', 'polldaddy' ), 'ratings' => __( 'Ratings', 'polldaddy' ) ) as $menu_slug => $page_title ) {
 			$menu_title  = $page_title;
 
-			$hook = add_submenu_page( $slug, $menu_title, $menu_title, $capability, $menu_slug, $function, 'div' );
+			$hook = add_submenu_page( $slug, $menu_title, $menu_title, $capability, $menu_slug, $function, 99 );
 			add_action( "load-$hook", array( &$this, 'management_page_load' ) );
 		}
 


### PR DESCRIPTION
Fixes some warnings due to misuse of `add_submenu_page` argument, reported  on https://wordpress.org/support/topic/v2-2-3-calls-add_submenu_page-improperly-barfs-errors/#post-14495595

The warning as shown on logs:

```
add_submenu_page was called incorrectly. The seventh parameter passed to add_submenu_page() should be an integer representing menu position. Please see Debugging in WordPress for more information. (This message was added in version 5.3.0.)
```

#### Changes proposed in this Pull Request:

  * Apply suggested changes to the `add_submenu_page` call, using an int as the *submenu* intended position.

#### Testing instructions:

  * Enable wanings/debug on a WP installation
  * Visit a wp-admin page and confirm the warning
  * Checkout `fix/add-submenu-page-argument` on an instance
  * Reload the wp-admin page and confirm the warning is not showing anymore
  * Confirm the menu/submenu entries are still functional and in the right place

