### PR TITLE
Fix/settings page link

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "polldaddy",
   "title": "Polldaddy Plugin",
-  "version": "2.2.0",
+  "version": "2.2.5",
   "homepage": "http://wordpress.org/plugins/polldaddy/",
   "license": "GPL-2.0+",
   "repository": "automattic/polldaddy-plugin",

--- a/polldaddy-org.php
+++ b/polldaddy-org.php
@@ -647,7 +647,7 @@ function polldaddy_login_warning() {
 		return;
 	}
 
-	echo '<div class="updated"><p><strong>' . sprintf( __( 'Warning! The Crowdsignal plugin must be linked to your Crowdsignal.com account. Please visit the <a href="%s">plugin settings page</a> to login.', 'polldaddy' ), admin_url( 'admin.php?page=polls&action=options' ) ) . '</strong></p></div>';
+	echo '<div class="updated"><p><strong>' . sprintf( __( 'Warning! The Crowdsignal plugin must be linked to your Crowdsignal.com account. Please visit the <a href="%s">plugin settings page</a> to login.', 'polldaddy' ), admin_url( 'options-general.php?page=pollsettings' ) ) . '</strong></p></div>';
 }
 add_action( 'admin_notices', 'polldaddy_login_warning' );
 

--- a/polldaddy.php
+++ b/polldaddy.php
@@ -5,7 +5,7 @@
  * Description: Create and manage Crowdsignal polls and ratings in WordPress
  * Author: Automattic, Inc.
  * Author URL: https://crowdsignal.com/
- * Version: 2.2.4
+ * Version: 2.2.5
  */
 
 // To hardcode your Polldaddy PartnerGUID (API Key), add the (uncommented) line below with the PartnerGUID to your `wp-config.php`
@@ -1509,8 +1509,8 @@ class WP_Polldaddy {
 			$polls_object = $polldaddy->get_polls_by_parent_id( ( $page - 1 ) * 10 + 1, $page * 10 );
 
 		$this->parse_errors( $polldaddy );
-        if ( in_array( 'API Key Not Found, 890', $polldaddy->errors ) )
-            return false;
+		if ( in_array( 'API Key Not Found, 890', $polldaddy->errors ) )
+			return false;
 		$this->print_errors();
 		$polls = & $polls_object->poll;
 		$total_polls = 0;

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: crowdsignal, polls, poll, polldaddy, wppolls, vote, polling, surveys, rate
 Requires at least: 4.6
 Requires PHP: 5.6
 Tested up to: 5.7.1
-Stable tag: 2.2.4
+Stable tag: 2.2.5
 
 Create and manage Crowdsignal polls and ratings from within WordPress.
 
@@ -126,6 +126,9 @@ Make sure to whitelist `api.crowdsignal.com` in your firewall to fix this.
 Bugfix release.
 
 == Changelog ==
+
+= 2.2.5 =
+* Change settings page link
 
 = 2.2.4 =
 * Fix wrong argument provided to get_submenu_page


### PR DESCRIPTION
Fixes account connection warning page link

#### Changes proposed in this Pull Request:

* Point warning link to correct (new) general settings page for self hosted installations

#### Testing instructions:

* Disconnect from Crowdsignal
* Try accessing wp-admin/admin.php?page=polls, confirm the link shown on the warning notice points to a blank list
* Checkout this branch
* Try again the mentioned link and see that it takes you to the settings page where the API key can be set

