### PR TITLE
Fix submenu issue

### DIFF
--- a/polldaddy.php
+++ b/polldaddy.php
@@ -187,7 +187,7 @@ class WP_Polldaddy {
 		foreach( array( 'polls' => __( 'Polls', 'polldaddy' ), 'ratings' => __( 'Ratings', 'polldaddy' ) ) as $menu_slug => $page_title ) {
 			$menu_title  = $page_title;
 
-			$hook = add_submenu_page( $slug, $menu_title, $menu_title, $capability, $menu_slug, $function, 99 );
+			$hook = add_submenu_page( $this->has_feedback_menu ? 'feedback' : $slug, $menu_title, $menu_title, $capability, $menu_slug, $function, 99 );
 			add_action( "load-$hook", array( &$this, 'management_page_load' ) );
 		}
 


### PR DESCRIPTION
This PR addresses an issue with Jetpack + Grunion Contact form fighting for the same submenu slugs.

#### Changes proposed in this Pull Request:

* Add the submenu depending on the class property `has_feedback_menu`

#### Testing instructions:

* Test on local environments (self hosted) by checking out the branch and installing/activating the plugin
* Test on AT sites, with and without Jetpack installed

At all times, the wp-admin sidebar should show the usual Feedback -> Polls / Ratings

#### Screenshot / Video

AT site with Jetpack:
![image](https://user-images.githubusercontent.com/157240/122617344-77c98500-d062-11eb-9f62-9cfbbc362dc8.png)

Self hosted:
![image](https://user-images.githubusercontent.com/157240/122617382-8ca61880-d062-11eb-847d-cb27d6eeb5fc.png)

After removing Jetpack from site:
![image](https://user-images.githubusercontent.com/157240/122617712-24a40200-d063-11eb-92a4-34f99b8d6c91.png)
