### PR TITLE
Allow page=polls&action=landing-page to forcibly render the landing page

### DIFF
--- a/polldaddy.php
+++ b/polldaddy.php
@@ -1438,6 +1438,9 @@ class WP_Polldaddy {
 							<?php
 							$this->style_edit_form();
 							break;
+						case 'landing-page':
+							$this->render_landing_page();
+							break;
 						default:
 							$view_type = 'me'; // default (and only) config for self-hosted.
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Add the option to forcibly render the landing page

#### Testing instructions:

* Checkout and test on local docker. Visit http://localhost:8000/wp-admin/admin.php?page=polls&action=landing-page 
* You should see our landing page

#### Screenshot / Video

(mind the left sidebar cutting as it reaches the viewport, this screenshot taken without scrolls, page looks as it should on the browser)
![landing-page](https://user-images.githubusercontent.com/157240/134937922-7fee3149-9f23-4730-821f-dc09f6dcd60f.png)

