### PR TITLE
Add "Get API Key" page.

### DIFF
--- a/partials/html-admin-setup-step-1.php
+++ b/partials/html-admin-setup-step-1.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * File containing the view for step 1 of the setup wizard.
+ *
+ * @package Crowdsignal_Forms\Admin
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+?>
+<div class="crowdsignal-setup__main">
+	<div class="crowdsignal-setup__content">
+		<h3><?php esc_html_e( 'Welcome to Crowdsignal', 'polldaddy' ); ?></h3>
+
+		<div class="crowdsignal-setup__description">
+			<p><?php echo wp_kses_post( 'To collect and manage respones you need to connect the plugin to <a href="https://crowdsignal.com">Crowdsignal</a>. <br />It will take less than a minute and it’s free.', 'polldaddy' ); ?></p>
+		</div>
+
+		<div class="wrap crowdsignal-settings-wrap">
+			<form id="cs-connect-form" class="crowdsignal-options" method="post" action="https://app.crowdsignal.com/get-api-key/" target="CSCONNECT">
+			<input type="hidden" name="get_api_key" value="<?php echo esc_attr( get_option( 'crowdsignal_api_key_secret' ) ); ?>" />
+			<input type="hidden" name="ref" value="<?php echo esc_attr( admin_url( 'options-general.php?page=crowdsignal-settings' ) ); ?>" />
+			<input type="submit" value="<?php esc_html_e( 'Let’s get started', 'polldaddy' ); ?>" class="crowdsignal-setup__button" />
+			</form>
+		</div>
+	</div>
+</div>
+
+<script>
+let CSCONNECT = null;
+const showConnect = ( title ) => {
+	// window size, match standard iPhone screen size
+	const widthRatio = 1/2;
+	const heightRatio = 3/4;
+
+	// Fixes dual-screen position
+	const dualScreenLeft = window.screenLeft !==  undefined
+		? window.screenLeft // Most browsers
+		: window.screenX; // Firefox
+	const dualScreenTop = window.screenTop !==  undefined
+		? window.screenTop // Most browsers
+		: window.screenY; // Firefox
+
+	const width = window.innerWidth
+		? window.innerWidth
+		: document.documentElement.clientWidth
+			? document.documentElement.clientWidth
+			: screen.width;
+	const height = window.innerHeight
+		? window.innerHeight
+		: document.documentElement.clientHeight
+			? document.documentElement.clientHeight
+			: screen.height;
+
+	const popupWidth = width * widthRatio;
+	const popupHeight = height * heightRatio;
+
+	const left = ( (width / 2 ) - ( popupWidth / 2 ) ) + dualScreenLeft;
+	const top = ( (height / 2 ) - ( popupHeight / 2 ) ) + dualScreenTop;
+
+	CSCONNECT = window.open( 'about:blank', title,
+		`
+		location=no, directories=no, status=no, menubar=no, scrollbars=no, resizable=no, copyhistory=no,
+		width=${ parseInt( popupWidth, 10 ) },
+		height=${ parseInt( popupHeight, 10 )  },
+		top=${ parseInt( top, 10 ) },
+		left=${ parseInt( left, 10 ) }
+		`
+	)
+
+	if ( window.focus ) CSCONNECT.focus();
+}
+( function( form ) {
+	form.onsubmit = function() {
+		showConnect( 'CSCONNECT' );
+	}
+} )( document.getElementById( 'cs-connect-form' ) );
+</script>

--- a/partials/html-admin-setup-step-2.php
+++ b/partials/html-admin-setup-step-2.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * File containing the view for step 2 of the setup wizard.
+ *
+ * @package Crowdsignal_Forms\Admin
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+if ( $connected ) {
+	$crowdsignal_forms_msg = 'connected';
+} else {
+	$crowdsignal_forms_msg = 'api-key-not-added';
+}
+?>
+<script type='text/javascript'>
+window.close();
+if (window.opener && !window.opener.closed) {
+	var querystring = window.opener.location.search;
+	querystring += ( querystring ? '&' : '?' ) + 'msg=<?php echo esc_js( $crowdsignal_forms_msg ); ?>';
+	window.opener.location.search = querystring;
+}
+</script>
+<noscript><h3><?php esc_html_e( "You're ready to start using Crowdsignal!", 'polldaddy' ); ?></h3></noscript>

--- a/partials/polls-table.php
+++ b/partials/polls-table.php
@@ -341,7 +341,7 @@ jQuery( document ).ready(function(){
 				icon: 'arrow-down',
 				controls: [
 					{ title: 'My Account', onClick: () => window.open( 'https://app.crowdsignal.com/account', '_blank' ) },
-					{ title: 'Settings', onClick: () => window.open( 'options-general.php?page=pollsettings', '_self' ) },
+					{ title: 'Settings', onClick: () => window.open( 'options-general.php?page=crowdsignal-settings', '_self' ) },
 					{ title: 'Crowdsignal Blog', onClick: () => window.open( 'https://crowdsignal.com/blog', '_blank' ) },
 					{ title: 'Help', onClick: () => window.open( 'https://crowdsignal.com/support', '_blank' ) },
 					{ title: 'crowdsignal.com', onClick: () => window.open( 'https://crowdsignal.com/', '_blank' ) },

--- a/polldaddy-org.php
+++ b/polldaddy-org.php
@@ -81,7 +81,7 @@ class WPORG_Polldaddy extends WP_Polldaddy {
 
 		$this->set_api_user_code();
 
-		if ( 'polls' === $page || 'pollsettings' === $page ) {
+		if ( 'polls' === $page || 'crowdsignal-settings' === $page ) {
 			switch ( $action ) {
 			case 'update-options' :
 				if ( !$is_POST )
@@ -658,7 +658,7 @@ function polldaddy_login_warning() {
 		return;
 	}
 
-	echo '<div class="updated"><p><strong>' . sprintf( __( 'Warning! The Crowdsignal plugin must be linked to your Crowdsignal.com account. Please visit the <a href="%s">plugin settings page</a> to login.', 'polldaddy' ), admin_url( 'options-general.php?page=pollsettings' ) ) . '</strong></p></div>';
+	echo '<div class="updated"><p><strong>' . sprintf( __( 'Warning! The Crowdsignal plugin must be linked to your Crowdsignal.com account. Please visit the <a href="%s">plugin settings page</a> to login.', 'polldaddy' ), admin_url( 'options-general.php?page=crowdsignal-settings' ) ) . '</strong></p></div>';
 }
 add_action( 'admin_notices', 'polldaddy_login_warning' );
 


### PR DESCRIPTION
This patch copies the "Get API Key" process from the Crowdsignal Forms plugin to this plugin.

The settings page has moved to crowdsignal-settings and so this patch includes a redirect from
pollsettings to make the transition smoother for anyone who has it bookmarked.
