### PR TITLE
Use CS_RATING_TITLE_FILTER instead of pd-rating-title-filter option

### DIFF
--- a/polldaddy-org.php
+++ b/polldaddy-org.php
@@ -117,12 +117,6 @@ class WPORG_Polldaddy extends WP_Polldaddy {
 					$polldaddy->update_partner_account( $partner );
 					update_option( 'polldaddy_multiple_accounts', $polldaddy_multiple_accounts );
 					update_option( 'polldaddy_load_poll_inline', $polldaddy_load_poll_inline );
-
-					$rating_title_filter = '';
-					if ( isset( $_POST['polldaddy-ratings-title-filter'] ) )
-						$rating_title_filter = sanitize_text_field( $_POST['polldaddy-ratings-title-filter'] );
-
-					update_option( 'pd-rating-title-filter', $rating_title_filter );
 				}
 				break;
 			} //end switch

--- a/rating.php
+++ b/rating.php
@@ -112,15 +112,16 @@ function polldaddy_get_rating_html( $condition = '' ) {
 		}
 
 		if ( $rating_id > 0 ) {
-			$rating_title_filter = get_option( 'pd-rating-title-filter' );
-			
-			if ( $rating_title_filter === false )
+			if ( defined( 'CS_RATING_TITLE_FILTER' ) ) {
+				if ( strlen( constant( 'CS_RATING_TITLE_FILTER' ) ) > 0 ) {
+					$title = apply_filters( constant( 'CS_RATING_TITLE_FILTER' ), $post->post_title, $post->ID, '' );
+				} else {
+					$title = $post->post_title;
+				}
+			} else {
 				$title = apply_filters( 'the_title', $post->post_title, $post->ID, '' );
-			elseif ( strlen( $rating_title_filter ) > 0 )
-				$title = apply_filters( $rating_title_filter, $post->post_title, $post->ID, '' );
-			else
-				$title = $post->post_title;
-				
+			}
+
 			$permalink = get_permalink( $post->ID );
 			$html = polldaddy_get_rating_code( $rating_id, $unique_id, $title, $permalink, $item_id );
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -111,7 +111,7 @@ You need to select the synchronize ratings account in the WordPress options page
 
 = When I try to use a rating on a page, I get a PHP warning about the post title. =
 
-Your rating uses the filter 'wp_title' by default when retrieving the post title, you may need to remove this in the Polls & Ratings settings to allow ratings to work with your theme.
+Your rating uses the filter 'wp_title' by default when retrieving the post title, you may need to remove this by defining the constant "CS_RATING_TITLE_FILTER" to a new filter to use, or just set it to "1" to allow ratings to work with your theme. Define the constant in wp-config.php or an mu-plugin.
 
 = Why is a poll loading in the footer of my main page? =
 

--- a/readme.txt
+++ b/readme.txt
@@ -111,7 +111,7 @@ You need to select the synchronize ratings account in the WordPress options page
 
 = When I try to use a rating on a page, I get a PHP warning about the post title. =
 
-Your rating uses the filter 'wp_title' by default when retrieving the post title, you may need to remove this by defining the constant "CS_RATING_TITLE_FILTER" to a new filter to use, or just set it to "1" to allow ratings to work with your theme. Define the constant in wp-config.php or an mu-plugin.
+Your rating uses the filter 'wp_title' by default when retrieving the post title, you may need to remove this by defining the constant "CS_RATING_TITLE_FILTER" to a new filter to use, or just set it to "" to diasable it and allow ratings to work with your theme. Define the constant in wp-config.php or an mu-plugin.
 
 = Why is a poll loading in the footer of my main page? =
 


### PR DESCRIPTION
The plugin used to have a setting for the "wp-title" filter that ratings use for the title of the rating but that is quite an advanced setting. Now a user can set a constant "CS_RATING_TITLE_FILTER" to change or disable this.

Set the constant to a new name which will be the new filter that the title of the rating is passed to for modification or set it to an empty string to disable the filter.