### PR TITLE
Remove Jetpack CSS and fix disconnect script. Update version

### DIFF
--- a/admin-styles.css
+++ b/admin-styles.css
@@ -15,16 +15,71 @@
 	font-weight: 700;
 }
 
-#jp-plugin-container .wrap {
+#cs-plugin-container {
+	min-height: 100vh;
+}
+
+#cs-plugin-container .wrap {
 	margin: 0 auto;
 	max-width:45rem;
 	padding: 0 1.5rem;
 }
-#jp-plugin-container.is-wide .wrap {
+#cs-plugin-container.is-wide .wrap {
 	max-width: 1040px;
 }
-#jp-plugin-container .wrap .jetpack-wrap-container {
+#cs-plugin-container .wrap .jetpack-wrap-container {
 	margin-top: 1em;
+}
+
+.cs-lower {
+	margin: 0 auto;
+	text-align: left;
+	max-width: 65rem;
+	padding: 1.5rem;
+}
+
+.cs-footer {
+	text-align: center;
+	margin: 1rem 0 2rem;
+}
+
+.cs-footer__a8c-attr-container {
+	margin-bottom: .5rem;
+}
+
+.cs-footer__a8c-attr {
+	width: 11.25rem;
+}
+
+.cs-footer__a8c-attr a {
+	color: #2271b1;
+}
+
+.cs-footer__links {
+	border-top: 1px #e1e1e1 solid;
+	border-bottom: 1px #e1e1e1 solid;
+	margin-top: 0;
+	margin-bottom: 1rem;
+}
+
+.cs-footer__link-item {
+	display: inline-block;
+}
+
+.cs-footer__link {
+	color: #888;
+	padding: 1rem .5rem;
+	color: #888;
+	display: inline-block;
+	cursor: pointer;
+}
+
+.cs-footer__link:hover, .cs-footer__link:active {
+  color: #272727;
+}
+
+.cs-footer__link:visited {
+  color: #888;
 }
 
 .wp-admin #dolly {
@@ -139,8 +194,8 @@
 	margin: 0 auto;
 }
 
-.dops-card h3,
-.dops-card h4 {
+.cs-card h3,
+.cs-card h4 {
 	font-family: Recoleta, sans-serif;
 	font-weight: 700;
 	font-size: 20px;
@@ -272,7 +327,7 @@ div.error.crowdsignal-message p {
 .crowdsignal-settings__main-content {
 }
 
-.dops-card {
+.cs-card {
 	display: block;
 	position: relative;
 	margin: 0 auto 10px;
@@ -282,12 +337,12 @@ div.error.crowdsignal-message p {
 	box-shadow: 0 0 0 1px #ccd0d4,0 1px 1px 1px rgba(0,0,0,.04);
 }
 
-.dops-card.is-compact {
+.cs-card.is-compact {
 	margin-bottom: 1px;
 	padding: 16px 24px;
 }
 
-.dops-section-header.dops-card {
+.cs-section-header.cs-card {
 	display: flex;
 	flex-wrap: wrap;
 	padding-top: .6875rem;
@@ -295,13 +350,13 @@ div.error.crowdsignal-message p {
 	position: relative;
 }
 
-.dops-section-header__label {
+.cs-section-header__label {
 	line-height: 1.75rem;
 	color: #414141;
 	font-size: .875rem;
 }
 
-.dops-section-header__label-text {
+.cs-section-header__label-text {
 	position: relative;
 	margin-right: .5rem;
 	white-space: nowrap;
@@ -356,17 +411,17 @@ div.error.crowdsignal-message p {
 	}
 }
 
-.jp-form-settings-group p {
+.cs-form-settings-group p {
 	color: #838383;
 	font-style: italic;
 	font-size: .875rem;
 	font-weight: 400;
 }
 
-.jp-form-settings-group a {
+.cs-form-settings-group a {
 }
 
-.jp-form-settings-group h2 {
+.cs-form-settings-group h2 {
 	font-size: .875rem;
 	font-weight: 700;
 }
@@ -410,3 +465,65 @@ div.error.crowdsignal-message p {
 	padding-left: 24px;
 }
 
+.cs-button {
+	background:#f6f7f7;
+	border:1px solid #2271b1;
+	color:#2271b1;
+	cursor:pointer;
+	display:inline-block;
+	margin:0;
+	outline:0;
+	overflow:hidden;
+	font-size:.875rem;
+	text-overflow:ellipsis;
+	text-decoration:none;
+	vertical-align:top;
+	box-sizing:border-box;
+	border-radius:3px;
+	padding:7px 14px 9px;
+	-webkit-appearance:none;
+	appearance:none
+}
+.cs-button:hover {
+	background:#f0f0f1;
+	border-color:#0a4b78;
+	color:#0a4b78
+}
+.cs-button:disabled,
+.cs-button[disabled] {
+	color:#eee;
+	background:#fff;
+	border-color:#eee;
+	cursor:default
+}
+.cs-button:focus {
+	background:#fff;
+	border-color:#2271b1;
+	box-shadow:0 0 0 1px #2271b1
+}
+.cs-button.hidden {
+	display:none
+}
+.cs-button.is-primary {
+	background:#3582c4;
+	border-color:#3582c4;
+	color:#fff
+}
+.cs-button.is-primary:focus,
+.cs-button.is-primary:hover {
+	border-color:#2271b1;
+	background:#2271b1;
+	color:#fff
+}
+.cs-button.is-primary:focus {
+	box-shadow:0 0 0 1px #fff,0 0 0 3px #2271b1
+}
+.cs-button.is-primary:disabled,
+.cs-button.is-primary[disabled] {
+	color:#66c6e4!important;
+	background-color:#008ec2!important;
+	border-color:#008ec2!important;
+	box-shadow:none!important;
+	text-shadow:none!important;
+	cursor:default
+}

--- a/css/polldaddy.css
+++ b/css/polldaddy.css
@@ -27,7 +27,6 @@
 }
 
 #manage-polls {
-	height: 100%;
 	margin-left: -20px;
 	margin-right: 0;
 	margin-top: 0;

--- a/css/polldaddy.css
+++ b/css/polldaddy.css
@@ -53,10 +53,6 @@ h2#polldaddy-header, h2#poll-list-header {
 	display: inline-block;
 }
 
-.cs-pre-wrap {
-	background: white;
-	height: 30px;
-}
 .cs-wrapper {
 	clear: both;
 	display: flex;
@@ -66,10 +62,6 @@ h2#polldaddy-header, h2#poll-list-header {
 }
 
 @media screen and (max-width: 782px) {
-	.cs-pre-wrap {
-		height: 60px;
-	}
-
 	.cs-wrapper {
 		min-height: calc(100% - 60px);
 	}

--- a/partials/html-admin-setup-footer.php
+++ b/partials/html-admin-setup-footer.php
@@ -10,20 +10,20 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 
-	<div class="jp-footer">
-		<div class="jp-footer__a8c-attr-container">
+	<div class="cs-footer">
+		<div class="cs-footer__a8c-attr-container">
 			<a href="https://automattic.com/">
-				<svg role="img" class="jp-footer__a8c-attr" x="0" y="0" viewBox="0 0 935 38.2" enable-background="new 0 0 935 38.2" aria-labelledby="a8c-svg-title">
+				<svg role="img" class="cs-footer__a8c-attr" x="0" y="0" viewBox="0 0 935 38.2" enable-background="new 0 0 935 38.2" aria-labelledby="a8c-svg-title">
 					<title id="a8c-svg-title">An Automattic Adventure</title>
 					<path d="M317.1 38.2c-12.6 0-20.7-9.1-20.7-18.5v-1.2c0-9.6 8.2-18.5 20.7-18.5 12.6 0 20.8 8.9 20.8 18.5v1.2C337.9 29.1 329.7 38.2 317.1 38.2zM331.2 18.6c0-6.9-5-13-14.1-13s-14 6.1-14 13v0.9c0 6.9 5 13.1 14 13.1s14.1-6.2 14.1-13.1V18.6zM175 36.8l-4.7-8.8h-20.9l-4.5 8.8h-7L157 1.3h5.5L182 36.8H175zM159.7 8.2L152 23.1h15.7L159.7 8.2zM212.4 38.2c-12.7 0-18.7-6.9-18.7-16.2V1.3h6.6v20.9c0 6.6 4.3 10.5 12.5 10.5 8.4 0 11.9-3.9 11.9-10.5V1.3h6.7V22C231.4 30.8 225.8 38.2 212.4 38.2zM268.6 6.8v30h-6.7v-30h-15.5V1.3h37.7v5.5H268.6zM397.3 36.8V8.7l-1.8 3.1 -14.9 25h-3.3l-14.7-25 -1.8-3.1v28.1h-6.5V1.3h9.2l14 24.4 1.7 3 1.7-3 13.9-24.4h9.1v35.5H397.3zM454.4 36.8l-4.7-8.8h-20.9l-4.5 8.8h-7l19.2-35.5h5.5l19.5 35.5H454.4zM439.1 8.2l-7.7 14.9h15.7L439.1 8.2zM488.4 6.8v30h-6.7v-30h-15.5V1.3h37.7v5.5H488.4zM537.3 6.8v30h-6.7v-30h-15.5V1.3h37.7v5.5H537.3zM569.3 36.8V4.6c2.7 0 3.7-1.4 3.7-3.4h2.8v35.5L569.3 36.8 569.3 36.8zM628 11.3c-3.2-2.9-7.9-5.7-14.2-5.7 -9.5 0-14.8 6.5-14.8 13.3v0.7c0 6.7 5.4 13 15.3 13 5.9 0 10.8-2.8 13.9-5.7l4 4.2c-3.9 3.8-10.5 7.1-18.3 7.1 -13.4 0-21.6-8.7-21.6-18.3v-1.2c0-9.6 8.9-18.7 21.9-18.7 7.5 0 14.3 3.1 18 7.1L628 11.3zM321.5 12.4c1.2 0.8 1.5 2.4 0.8 3.6l-6.1 9.4c-0.8 1.2-2.4 1.6-3.6 0.8l0 0c-1.2-0.8-1.5-2.4-0.8-3.6l6.1-9.4C318.7 11.9 320.3 11.6 321.5 12.4L321.5 12.4z"></path>
 				</svg>
 			</a>
 		</div>
-		<ul class="jp-footer__links">
-			<li class="jp-footer__link-item"><a href="https://crowdsignal.com" target="_blank" rel="noopener noreferrer" class="jp-footer__link" title="Crowdsignal">Crowdsignal.com</a></li>
-			<li class="jp-footer__link-item"><a href="https://crowdsignal.com/support" target="_blank" rel="noopener noreferrer" class="jp-footer__link" title="<?php esc_html_e( 'Crowdsignal Support', 'crowdsignal-forms' ); ?>"><?php esc_html_e( 'Support', 'crowdsignal-forms' ); ?></a></li>
-			<li class="jp-footer__link-item"><a href="https://crowdsignal.com/terms/" target="_blank" rel="noopener noreferrer" title="<?php esc_attr_e( 'Terms of Service', 'crowdsignal-forms' ); ?>" class="jp-footer__link"><?php esc_html_e( 'Terms', 'crowdsignal-forms' ); ?></a></li>
-			<li class="jp-footer__link-item"><a href="https://automattic.com/privacy/" target="_blank" rel="noopener noreferrer" title="<?php esc_attr_e( 'Privacy Policy', 'crowdsignal-forms' ); ?>" class="jp-footer__link"><?php esc_html_e( 'Privacy', 'crowdsignal-forms' ); ?></a></li>
+		<ul class="cs-footer__links">
+			<li class="cs-footer__link-item"><a href="https://crowdsignal.com" target="_blank" rel="noopener noreferrer" class="cs-footer__link" title="Crowdsignal">Crowdsignal.com</a></li>
+			<li class="cs-footer__link-item"><a href="https://crowdsignal.com/support" target="_blank" rel="noopener noreferrer" class="cs-footer__link" title="<?php esc_html_e( 'Crowdsignal Support', 'crowdsignal-forms' ); ?>"><?php esc_html_e( 'Support', 'crowdsignal-forms' ); ?></a></li>
+			<li class="cs-footer__link-item"><a href="https://crowdsignal.com/terms/" target="_blank" rel="noopener noreferrer" title="<?php esc_attr_e( 'Terms of Service', 'crowdsignal-forms' ); ?>" class="cs-footer__link"><?php esc_html_e( 'Terms', 'crowdsignal-forms' ); ?></a></li>
+			<li class="cs-footer__link-item"><a href="https://automattic.com/privacy/" target="_blank" rel="noopener noreferrer" title="<?php esc_attr_e( 'Privacy Policy', 'crowdsignal-forms' ); ?>" class="cs-footer__link"><?php esc_html_e( 'Privacy', 'crowdsignal-forms' ); ?></a></li>
 		</ul>
 	</div>
 </div> <!--.wrap-->

--- a/partials/html-admin-setup-header.php
+++ b/partials/html-admin-setup-header.php
@@ -10,8 +10,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 <div>
-	<div id="jp-plugin-container">
-		<div class='jp-lower'>
+	<div id="cs-plugin-container">
+		<div class='cs-lower'>
 			<h1 id='crowdsignal__logo'><?php esc_html_e( 'Crowdsignal Settings', 'crowdsignal-forms' ); ?></h1>
 	<?php
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
@@ -21,35 +21,30 @@ if ( ! defined( 'ABSPATH' ) ) {
 			case 'disconnect-fail':
 				echo '<div class="error fade crowdsignal-message"><p>' .
 				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Content is svg from internal lib
-				Crowdsignal_Forms\Admin\Crowdsignal_Forms_Setup::get_icon( 'warning' ) .
 				esc_html__( 'Could not disconnect. Please try again.', 'crowdsignal-forms' ) .
 				'</p></div>';
 				break;
 			case 'disconnected':
 				echo '<div class="updated fade crowdsignal-message"><p>' .
 				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Content is svg from internal lib
-				Crowdsignal_Forms\Admin\Crowdsignal_Forms_Setup::get_icon( 'success' ) .
 				esc_html__( 'Successfully disconnected from Crowdsignal.', 'crowdsignal-forms' ) .
 				'</p></div>';
 				break;
 			case 'connected':
 				echo '<div class="updated crowdsignal-message"><p>' .
 				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Content is svg from internal lib
-				Crowdsignal_Forms\Admin\Crowdsignal_Forms_Setup::get_icon( 'success' ) .
 				esc_html__( 'Success! Your Crowdsignal account is successfully connected! You are ready!', 'crowdsignal-forms' ) .
 				'</p></div>';
 				break;
 			case 'api-key-added':
 				echo '<div class="updated crowdsignal-message"><p>' .
 				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Content is svg from internal lib
-				Crowdsignal_Forms\Admin\Crowdsignal_Forms_Setup::get_icon( 'success' ) .
 				esc_html__( 'You have been connected to Crowdsignal.', 'crowdsignal-forms' ) .
 				'</p></div>';
 				break;
 			case 'api-key-not-added':
 				echo '<div class="error fade crowdsignal-message"><p>' .
 				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Content is svg from internal lib
-				Crowdsignal_Forms\Admin\Crowdsignal_Forms_Setup::get_icon( 'warning' ) .
 				esc_html__( 'Your API key has not been updated, please try again.', 'crowdsignal-forms' ) .
 				'</p></div>';
 				break;

--- a/partials/html-admin-setup-step-1.php
+++ b/partials/html-admin-setup-step-1.php
@@ -10,16 +10,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 			<br />
-			<div class='jp-settings-container'>
-				<div class="dops-card dops-section-header is-compact">
-					<div class="dops-section-header__label">
-						<span class="dops-section-header__label-text"><?php esc_html_e( 'Getting Started', 'crowdsignal-forms' ); ?></span>
+			<div class='cs-settings-container'>
+				<div class="cs-card cs-section-header is-compact">
+					<div class="cs-section-header__label">
+						<span class="cs-section-header__label-text"><?php esc_html_e( 'Getting Started', 'crowdsignal-forms' ); ?></span>
 					</div>
 				</div>
 
-				<div class="dops-card dops-section-header is-compact">
+				<div class="cs-card cs-section-header is-compact">
 
-					<div class="jp-form-settings-group crowdsignal-forms" style='text-align: center; width: 100%'>
+					<div class="cs-form-settings-group crowdsignal-forms" style='text-align: center; width: 100%'>
 						<div class="crowdsignal-setup__content">
 							<div class="crowdsignal-setup__description">
 								<h1><?php esc_html_e( 'Welcome to Crowdsignal', 'crowdsignal-forms' ); ?></h1>
@@ -30,7 +30,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 								<form id="cs-connect-form" class="crowdsignal-options" method="post" action="https://app.crowdsignal.com/get-api-key/" target="CSCONNECT">
 									<input type="hidden" name="get_api_key" value="<?php echo esc_attr( get_option( 'crowdsignal_api_key_secret' ) ); ?>" />
 									<input type="hidden" name="ref" value="<?php echo esc_attr( admin_url( 'options-general.php?page=crowdsignal-settings' ) ); ?>" />
-									<input type="submit" value="<?php esc_html_e( 'Let’s get started', 'polldaddy' ); ?>" class="dops-button is-primary" />
+									<input type="submit" value="<?php esc_html_e( 'Let’s get started', 'polldaddy' ); ?>" class="cs-button is-primary" />
 								</form>
 							</div>
 						</div>

--- a/partials/html-admin-setup-step-3.php
+++ b/partials/html-admin-setup-step-3.php
@@ -10,15 +10,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 			<br />
-			<div class='jp-settings-container'>
-				<div class="dops-card dops-section-header is-compact">
-					<div class="dops-section-header__label">
-						<span class="dops-section-header__label-text"><?php esc_html_e( 'Getting Started', 'polldaddy' ); ?></span>
+			<div class='cs-settings-container'>
+				<div class="cs-card cs-section-header is-compact">
+					<div class="cs-section-header__label">
+						<span class="cs-section-header__label-text"><?php esc_html_e( 'Getting Started', 'polldaddy' ); ?></span>
 					</div>
 				</div>
 
-				<div class="dops-card dops-section-header is-compact">
-					<div class="jp-form-settings-group" style='width: 100%'>
+				<div class="cs-card cs-section-header is-compact">
+					<div class="cs-form-settings-group" style='width: 100%'>
 						<h2><?php echo wp_kses_post( __( 'First time using Crowdsignal?', 'polldaddy' ) ); ?></h2>
 						<div class="crowdsignal-setup__middle">
 							<p>

--- a/partials/html-admin-teaser.php
+++ b/partials/html-admin-teaser.php
@@ -10,15 +10,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 		<br />
-		<div class='jp-settings-container'>
-			<div class="dops-card dops-section-header is-compact">
-				<div class="dops-section-header__label">
-					<span class="dops-section-header__label-text"><?php esc_html_e( 'Crowdsignal Blocks', 'polldaddy' ); ?></span>
+		<div class='cs-settings-container'>
+			<div class="cs-card cs-section-header is-compact">
+				<div class="cs-section-header__label">
+					<span class="cs-section-header__label-text"><?php esc_html_e( 'Crowdsignal Blocks', 'polldaddy' ); ?></span>
 				</div>
 			</div>
 
-			<div class="dops-card dops-section-header is-compact">
-				<div class="jp-form-settings-group" style='width: 100%'>
+			<div class="cs-card cs-section-header is-compact">
+				<div class="cs-form-settings-group" style='width: 100%'>
 					<h2><?php echo wp_kses_post( __( 'First time using Crowdsignal?', 'polldaddy' ) ); ?></h2>
 					<div class="crowdsignal-setup__middle">
 						<p>

--- a/partials/settings-2.php
+++ b/partials/settings-2.php
@@ -22,9 +22,9 @@ jQuery(document).ready( function() {
 			<div style='display:none' id="crowdsignal__advanced_page">
 
 				<?php if ( $controller->multiple_accounts ) { ?>
-				<div class='jp-settings-container'>
-					<div class="dops-card dops-section-header is-compact">
-						<div class="jp-form-settings-group" style='width: 100%'>
+				<div class='cs-settings-container'>
+					<div class="cs-card cs-section-header is-compact">
+						<div class="cs-form-settings-group" style='width: 100%'>
 							<h2><?php echo wp_kses_post( __( 'Multiuser Account', 'polldaddy' ) ); ?></h2>
 							<div class="crowdsignal-setup__middle">
 								<form action="" method="post">
@@ -60,8 +60,8 @@ if ( ! $show_reset_form && empty( $previous_settings ) ) {
 }
 ?>
 
-				<div class='jp-settings-container'>
-					<div class="dops-card dops-section-header is-compact">
+				<div class='cs-settings-container'>
+					<div class="cs-card cs-section-header is-compact">
 						<div class="" style='width: 100%'>
 							<h2><?php echo wp_kses_post( __( 'Reset Connection Settings', 'polldaddy' ) ); ?></h2>
 							<div class="crowdsignal-setup__middle">

--- a/partials/settings.php
+++ b/partials/settings.php
@@ -7,15 +7,15 @@
 
 ?>
 <?php // phpcs:ignoreFile -- too many legacy warnings, needs full linter ?>
-			<div class='jp-settings-container'>
-				<div class="dops-card dops-section-header is-compact">
-					<div class="dops-section-header__label">
-						<span class="dops-section-header__label-text"><?php esc_html_e( 'Account Settings', 'crowdsignal-forms' ); ?></span>
+			<div class='cs-settings-container'>
+				<div class="cs-card cs-section-header is-compact">
+					<div class="cs-section-header__label">
+						<span class="cs-section-header__label-text"><?php esc_html_e( 'Account Settings', 'crowdsignal-forms' ); ?></span>
 					</div>
 				</div>
 
-				<div class="dops-card dops-section-header is-compact">
-					<div class="jp-form-settings-group">
+				<div class="cs-card cs-section-header is-compact">
+					<div class="cs-form-settings-group">
 						<h2><?php esc_html_e( 'API Key', 'crowdsignal-forms' ); ?></h2>
 						<p>
 			<?php
@@ -43,7 +43,7 @@
 						<form id="cs-connect-form" class="crowdsignal-options" method="post" action="https://app.crowdsignal.com/get-api-key/" target="CSCONNECT">
 						<input type="hidden" name="get_api_key" value="<?php echo esc_attr( get_option( 'crowdsignal_api_key_secret' ) ); ?>" />
 						<input type="hidden" name="ref" value="<?php echo esc_attr( admin_url( 'options-general.php?page=crowdsignal-settings' ) ); ?>" />
-						<input type="submit" value="<?php esc_html_e( 'Get API Key', 'crowdsignal-forms' ); ?>" class="dops-button is-primary" />
+						<input type="submit" value="<?php esc_html_e( 'Get API Key', 'crowdsignal-forms' ); ?>" class="cs-button is-primary" />
 						</form>
 						</p>
 			<?php } ?>

--- a/polldaddy.php
+++ b/polldaddy.php
@@ -5,7 +5,7 @@
  * Description: Create and manage Crowdsignal polls and ratings in WordPress
  * Author: Automattic, Inc.
  * Author URL: https://crowdsignal.com/
- * Version: 3.0.4
+ * Version: 3.0.5
  */
 
 // To hardcode your Polldaddy PartnerGUID (API Key), add the (uncommented) line below with the PartnerGUID to your `wp-config.php`
@@ -467,6 +467,15 @@ class WP_Polldaddy {
 			die();
 		}
 
+		if ( isset( $_POST['action'] ) && $_POST['action'] === 'disconnect' ) {
+			check_admin_referer( 'disconnect-api-key' );
+			delete_option( 'polldaddy_api_key' );
+			delete_option( 'crowdsignal_api_key' );
+			delete_option( 'crowdsignal_user_code' );
+			delete_option( 'pd-usercode-' . $this->id );
+			wp_safe_redirect( admin_url( 'options-general.php?page=crowdsignal-settings&msg=disconnected' ) );
+		}
+
 		$this->set_api_user_code();
 
 		if ( empty( $this->user_code ) && 'crowdsignal-settings' === $page && 'options' !== $action ) {
@@ -478,9 +487,6 @@ class WP_Polldaddy {
 
 		require_once WP_POLLDADDY__POLLDADDY_CLIENT_PATH;
 
-		wp_enqueue_style( 'jetpack-styles1', 'https://c0.wp.com/p/jetpack/10.0/_inc/build/style.min.css', array(), '1.5.7' );
-		wp_enqueue_style( 'jetpack-styles2', 'https://c0.wp.com/c/5.8.1/wp-admin/css/common.min.css', array(), '1.5.7' );
-		wp_enqueue_style( 'jetpack-styles3', 'https://c0.wp.com/p/jetpack/10.0/_inc/build/admin.css', array(), '1.5.7' );
 		wp_enqueue_style( 'admin-styles', plugin_dir_url( __FILE__ ) . '/admin-styles.css', array(), '1.5.12' );
 		wp_enqueue_style( 'wp-components' );
 		wp_enqueue_script( 'polls', "{$this->base_url}js/polldaddy.js", array( 'jquery', 'jquery-ui-sortable', 'jquery-form', 'wp-components' ), $this->version );

--- a/polldaddy.php
+++ b/polldaddy.php
@@ -1718,7 +1718,6 @@ class WP_Polldaddy {
 		?>
 
 		<div class="wrap" id="manage-polls">
-			<div class="cs-pre-wrap"></div>
 			<div class="cs-wrapper">
 				<?php
 				if ( 'polls' === $page ) {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: crowdsignal, polls, poll, polldaddy, wppolls, vote, polling, surveys, rate
 Requires at least: 5.5
 Requires PHP: 5.6
 Tested up to: 5.8.2
-Stable tag: 3.0.4
+Stable tag: 3.0.5
 
 == Description ==
 


### PR DESCRIPTION
This patch removes our dependency on the Jetpack CSS and renames all elements so there shouldn't be any conflict.

It also adds code to disconnect the blog from Crowdsignal.

Bumped the version to 3.0.5
