### PR TITLE
fix typo on respones -> responses

### DIFF
--- a/partials/html-admin-setup-step-1.php
+++ b/partials/html-admin-setup-step-1.php
@@ -23,7 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 						<div class="crowdsignal-setup__content">
 							<div class="crowdsignal-setup__description">
 								<h1><?php esc_html_e( 'Welcome to Crowdsignal', 'crowdsignal-forms' ); ?></h1>
-								<p><?php echo wp_kses_post( 'To collect and manage respones you need to connect the plugin to <a href="https://crowdsignal.com">Crowdsignal</a>. <br />It will take less than a minute and it’s free.', 'polldaddy' ); ?></p>
+								<p><?php echo wp_kses_post( 'To collect and manage responses you need to connect the plugin to <a href="https://crowdsignal.com">Crowdsignal</a>. <br />It will take less than a minute and it’s free.', 'polldaddy' ); ?></p>
 							</div>
 
 							<div class="wrap crowdsignal-settings-wrap">


### PR DESCRIPTION
Fixes a typo on the setup start screen

This PR is just a minor typo fix to replace "respones" with "responses" on the setup page.

#### Testing instructions:

Checkout and go to main plugin settings. If already connected, disconnect. You should see this screen:
![image](https://user-images.githubusercontent.com/157240/149975792-2a4d75e3-6484-48e8-845b-a4bde78e4eb7.png)

See that it reads "responses" and not "respones"