### PR TITLE
Insted of PollsCrowdsignal have Dashboard | Crowdsignal

### DIFF
--- a/polldaddy-org.php
+++ b/polldaddy-org.php
@@ -63,7 +63,7 @@ class WPORG_Polldaddy extends WP_Polldaddy {
 		if ( $page == 'ratings' )
 			return (stripos( $admin_title, $page ) === false ? __( "Ratings", "polldaddy" ) : '' ).$admin_title;
 		elseif ( $page == 'polls' )
-			return (stripos( $admin_title, $page ) === false ? __( "Polls", "polldaddy" ) : '' ).$admin_title;
+			return (stripos( $admin_title, $page ) === false ? __( "Dashboard", "polldaddy" ) : '' ) . ' | ' . $admin_title;
 
 		return $admin_title;
 	}


### PR DESCRIPTION
The page title of Feedback->Crowdsignal shows "PollsCrowdsignal &lsaquo; WordPress Site" currently.

This patch changes that title to "Dashboard | Crowdsignal &lsaquo; WordPress Site".

Apply patch
Load up Feedback->Crowdsignal and hover over your browser tab to see the change to the title.