### PR TITLE
Only admins should be able to load the rating settings page

### DIFF
--- a/polldaddy.php
+++ b/polldaddy.php
@@ -202,7 +202,7 @@ class WP_Polldaddy {
 		foreach( array( 'crowdsignal-settings' => __( 'Crowdsignal', 'polldaddy' ), 'ratingsettings' => __( 'Ratings', 'polldaddy' ) ) as $menu_slug => $page_title ) {
 			// translators: %s placeholder is the setting page type (Poll or Rating).
 			$settings_page_title = sprintf( esc_html__( '%s', 'polldaddy' ), $page_title );
-			$hook = add_options_page( $settings_page_title, $settings_page_title, $menu_slug == 'ratings' ? 'manage_options' : $capability, $menu_slug, array( $this, 'settings_page' ) );
+			$hook = add_options_page( $settings_page_title, $settings_page_title, $menu_slug == 'ratingsettings' ? 'manage_options' : $capability, $menu_slug, array( $this, 'settings_page' ) );
 			add_action( "load-$hook", array( $this, 'management_page_load' ) );
 		}
 


### PR DESCRIPTION
The rating settings page allows a user to change sitewide rating settings such as displaying ratings on posts or archives. Therefore only an admin user should be allowed to access it.

This patch fixes the permission check when creating the options page so that "manage_options" permission is required (again) to load this page.

Props @apapedulimu for reporting this.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Fix permissions check on rating settings page.
