### PR TITLE
Fix/api disconnect perms

### DIFF
--- a/polldaddy.php
+++ b/polldaddy.php
@@ -470,7 +470,7 @@ class WP_Polldaddy {
 		if (
 			isset( $_POST['action'] )
 			&& $_POST['action'] === 'disconnect'
-			&& current_user_can( 'edit_posts' )
+			&& current_user_can( 'edit_others_posts' )
 		) {
 			check_admin_referer( 'disconnect-api-key' );
 			delete_option( 'polldaddy_api_key' );
@@ -1697,7 +1697,7 @@ class WP_Polldaddy {
 					$page = $_GET['page']; // phpcs:ignore
 				}
 				if ( 'crowdsignal-settings' === $page ) {
-					if ( ! current_user_can( 'edit_posts' ) ) { // check user privileges has access to action.
+					if ( ! current_user_can( 'edit_others_posts' ) ) { // check user privileges has access to action.
 						return;
 					}
 					$this->plugin_options();

--- a/polldaddy.php
+++ b/polldaddy.php
@@ -467,7 +467,11 @@ class WP_Polldaddy {
 			die();
 		}
 
-		if ( isset( $_POST['action'] ) && $_POST['action'] === 'disconnect' ) {
+		if (
+			isset( $_POST['action'] )
+			&& $_POST['action'] === 'disconnect'
+			&& current_user_can( 'edit_posts' )
+		) {
 			check_admin_referer( 'disconnect-api-key' );
 			delete_option( 'polldaddy_api_key' );
 			delete_option( 'crowdsignal_api_key' );
@@ -1693,7 +1697,7 @@ class WP_Polldaddy {
 					$page = $_GET['page']; // phpcs:ignore
 				}
 				if ( 'crowdsignal-settings' === $page ) {
-					if ( ! $this->is_author ) { // check user privileges has access to action.
+					if ( ! current_user_can( 'edit_posts' ) ) { // check user privileges has access to action.
 						return;
 					}
 					$this->plugin_options();


### PR DESCRIPTION
Tighten up the permission checks for disconnecting the API through the settings page.

Only an editor or better can connect or disconnect it when this PR is applied.