### PR TITLE
declare properties so they are not considered dynamic in php 8.2

### DIFF
--- a/polldaddy.php
+++ b/polldaddy.php
@@ -44,6 +44,7 @@ class WP_Polldaddy {
 	var $base_url;
 	var $is_admin;
 	var $is_author;
+	var $is_editor;
 	var $scheme;
 	var $version;
 	var $polldaddy_client_class;
@@ -53,6 +54,7 @@ class WP_Polldaddy {
 	var $user_code;
 	var $rating_user_code;
 	var $has_feedback_menu;
+	var $has_crowdsignal_blocks;
 
 	public $has_items = array();
 


### PR DESCRIPTION
Fixes PHP 8.2 deprecation warnings related to dynamic properties.

#### Changes proposed in this Pull Request:

* Declare `is_editor` and `has_crowdsignal_blocks` before assignment.

#### Testing instructions:

*

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
#### Screenshot / Video



<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
