### PR TITLE
Remove usage of dynamic properties

### DIFF
--- a/polldaddy-client.php
+++ b/polldaddy-client.php
@@ -144,12 +144,8 @@ class api_client {
 	function reset() {
 		$this->request       = null;
 		$this->response      = null;
-		$this->request_data  = '';
-		$this->response_data = '';
 		$this->request_xml   = '';
 		$this->response_xml  = '';
-		$this->request_json  = '';
-		$this->response_json = '';
 		$this->errors        = array();
 	}
 

--- a/polldaddy-xml.php
+++ b/polldaddy-xml.php
@@ -1,5 +1,6 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+#[AllowDynamicProperties]
 class Ghetto_XML_Object {
 	function __construct( $args = null, $attributes = null ) {
 		if ( get_object_vars( $this ) )

--- a/polldaddy.php
+++ b/polldaddy.php
@@ -53,6 +53,8 @@ class WP_Polldaddy {
 	var $user_code;
 	var $rating_user_code;
 	var $has_feedback_menu;
+	var $is_editor;
+	var $has_crowdsignal_blocks;
 
 	public $has_items = array();
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Remove dynamic properties usage on the plugin

#### Testing instructions:

Using this plugin on a WP installation running PHP 8.2:

1. Create a quiz, test the blocks and other pages related to Crowdsignal on WP
2. Verify if there are no deprecation errors related to PHP 8.2 on the plugin


<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

Add support for PHP 8.2
