### PR TITLE
Fix: Make 'Results' and 'Edit' Links Always Visible on Polls Dashboard

### DIFF
--- a/css/polldaddy.css
+++ b/css/polldaddy.css
@@ -95,7 +95,7 @@ table.cs-dashboard__grid .is-links a {
 	font-weight: bold;
 	padding-left: 4px;
 	padding-right: 4px;
-	visibility: hidden;
+
 }
 
 table.cs-dashboard__grid .is-type img {
@@ -104,9 +104,6 @@ table.cs-dashboard__grid .is-type img {
 
 table.cs-dashboard__grid tr:hover td {
 	background-color: #f6f6f6;
-}
-table.cs-dashboard__grid tr:hover .is-links a {
-	visibility: visible;
 }
 
 .cs-dashboard__mq-desktop-only {

--- a/css/polldaddy.css
+++ b/css/polldaddy.css
@@ -95,7 +95,7 @@ table.cs-dashboard__grid .is-links a {
 	font-weight: bold;
 	padding-left: 4px;
 	padding-right: 4px;
-
+	opacity: 0.7;
 }
 
 table.cs-dashboard__grid .is-type img {
@@ -104,6 +104,9 @@ table.cs-dashboard__grid .is-type img {
 
 table.cs-dashboard__grid tr:hover td {
 	background-color: #f6f6f6;
+}
+table.cs-dashboard__grid tr:hover .is-links a {
+	opacity: 1;
 }
 
 .cs-dashboard__mq-desktop-only {


### PR DESCRIPTION
#### Summary
This PR addresses issue [#107](https://github.com/Automattic/crowdsignal-plugin/issues/107), which highlights a UX/UI anti-pattern where the "Results" and "Edit" links on the Polls page (`wp-admin/admin.php?page=polls`) are hidden until hover. This behavior negatively impacts usability and accessibility, as users may not immediately realize that these options are available.

#### Problem Description
Currently, the "Results" and "Edit" links for each poll are hidden by default and only become visible when hovering over the poll title. This design:
- Reduces discoverability for users unfamiliar with the interface.
- Hinders accessibility for users relying on assistive technologies or touch devices, where hover states are non-existent.

#### Proposed Solution
The solution implemented in this PR ensures that the "Results" and "Edit" links are always visible on page load. To maintain a clean UI:
- The links are slightly deemphasized (e.g., with reduced opacity or a lighter color) when not actively hovered over.
- On hover, the links regain full emphasis to indicate interactivity.

#### Implementation Details
- Updated the CSS to ensure the visibility of the links by default.
- Used opacity and hover styles to differentiate between interactive and inactive states.
- Verified compatibility with different themes and screen reader tools to ensure accessibility.

#### Steps to Test
1. Navigate to the Polls dashboard (`wp-admin/admin.php?page=polls`).
2. Observe that the "Results" and "Edit" links for each poll are visible on page load.
3. Hover over the links and confirm that they gain full emphasis.
4. Test on both desktop and mobile devices to ensure consistent behavior.

- Links visible by default, with hover effect applied .
<img width="1469" alt="Screenshot 2025-05-08 at 1 04 48 PM" src="https://github.com/user-attachments/assets/e9077ff9-d858-47e8-b581-82a144a89e13" />
<img width="1435" alt="Screenshot 2025-05-08 at 1 04 57 PM" src="https://github.com/user-attachments/assets/0ddca800-b350-4519-b5ae-e194ca00c40c" />


