### PR TITLE
Fix broken Crowdsignal poll scripts by updating polldaddy.com domain

### DIFF
--- a/polldaddy-shortcode.php
+++ b/polldaddy-shortcode.php
@@ -180,7 +180,7 @@ CONTAINER;
 
 			$poll      = intval( $poll );
 			$poll_url  = sprintf( 'https://poll.fm/%d', $poll );
-			$poll_js   = sprintf( '%s.polldaddy.com/p/%d.js', '//static', $poll );
+			$poll_js   = sprintf( '%s.polldaddy.com/p/%d.js', '//secure', $poll );
 			$poll_link = sprintf( '<a href="%s">Take Our Poll</a>', $poll_url );
 
 			if ( $no_script ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Fix broken Crowdsignal poll scripts by replacing hardcoded `static.polldaddy.com` with `secure.polldaddy.com`
* Ensures consistency between shortcode and embed functionality - both now use the working secure domain
* Resolves 404 errors that prevent polls from loading when using shortcodes

#### Testing instructions:
* Create a test post/page with a Crowdsignal poll shortcode
* Before fix: Verify that `static.polldaddy.com` script returns 404 Not Found in browser dev tools
* Apply the changes from this PR
* After fix: Confirm that `secure.polldaddy.com` script loads successfully and poll renders correctly
* Test that existing embed functionality continues to work without issues
* Verify polls are interactive and data submission works properly


#### Screenshot / Video
**Before**
<img width="1159" height="525" alt="Screenshot 2025-09-18 at 10 08 49 PM" src="https://github.com/user-attachments/assets/ae423bf1-8788-40de-89ca-20440912bee5" />

**After**
<img width="1147" height="536" alt="Screenshot 2025-09-18 at 10 09 35 PM" src="https://github.com/user-attachments/assets/0116e50c-9fec-4ec5-9cf0-d11b09e3726f" />

#### Proposed changelog entry for your changes:
* Fixed: Crowdsignal poll shortcodes now load properly by using the correct secure.polldaddy.com domain instead of the broken static.polldaddy.com