### PR TITLE
fix: Update .wp-env.json to set core to null

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,5 +1,5 @@
 {
-  "core": "WordPress/WordPress#latest",
+  "core": null,
   "phpVersion": "8.3",
   "plugins": [
     "."


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* The `.wp-env.json` file had an invalid version of `core`.

#### Testing instructions:

* If you try to run `wp-env start` without the fix, it will fail.
* If you run it after, the environment will start correctly.
