### PR TITLE
fix: Update item count field ID in polldaddy-org.php

### DIFF
--- a/polldaddy-org.php
+++ b/polldaddy-org.php
@@ -612,7 +612,7 @@ EOD;
         			</label>
     			</p>
 				<p>
-					<label for="rss-items-<?php echo esc_attr( $number ); ?>"><?php _e( 'How many items would you like to display?', 'polldaddy' ); ?>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'item_count' ) ); ?>"><?php _e( 'How many items would you like to display?', 'polldaddy' ); ?>
 							<select id="<?php echo esc_attr( $this->get_field_id( 'item_count' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'item_count' ) ); ?>">
 						<?php
 	for ( $i = 1; $i <= 20; ++$i )


### PR DESCRIPTION
Fixes #66.

#### Changes proposed in this Pull Request:

* Fix an invalid `for` attribute value on a label.

#### Testing instructions:

* Activate a non-block theme, to enable Apperance -> Widgets.
* Add a Top Rated widget to a widget area.
* Click the "How many items..." label, and see that the select field below is it is not focused (pressing Space does not activate the dropdown).
* Apply the fix, reload the page, and see that the label and field element are now linked.
* This can also be tested by looking at the Accessibility panel in the browser Dev Tools.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
#### Screenshot / Video

<img width="1050" height="652" alt="Screenshot 2025-09-22 at 18 28 57" src="https://github.com/user-attachments/assets/6f1a29dd-b318-4bb4-8375-86c473dce974" />


<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Fix: Associate widget label with form field for accessibility reasons.