### PR TITLE
Remove redundant hook with undefined function register_polldaddy_styles

### DIFF
--- a/polldaddy.php
+++ b/polldaddy.php
@@ -163,7 +163,6 @@ class WP_Polldaddy {
 			wp_safe_redirect( admin_url( 'options-general.php?page=crowdsignal-settings' ) );
 			die();
 		}
-		add_action( 'wp_enqueue_scripts', array( &$this, 'register_polldaddy_styles' ) );
 		add_action( 'admin_enqueue_scripts', array( &$this, 'menu_alter' ) );
 
 		if ( !defined( 'WP_POLLDADDY__PARTNERGUID' ) ) {


### PR DESCRIPTION
#### Fixes #127
#### Changes proposed in this Pull Request:

* Removes redundant add_action hook with non-existing function leading to fatal error in some scenarios.

`add_action( 'wp_enqueue_scripts', array( &$this, 'register_polldaddy_styles' ) );`

#### Testing instructions:

Install and activate Polldaddy, along with it install and activate the TOC plugin https://wordpress.org/plugins/table-of-contents-plus/

And then if you add the shortcode [TOC] in a page, you'd get a fatal error when trying to edit the page.

The reason being, TOC plugin adds the action:
do_action( 'wp_enqueue_scripts' );

And since polldaddy is hooking a non-existing function it leads to fatal error.

#### Screenshot / Video
<img width="1363" height="354" alt="Screenshot 2025-09-23 at 6 41 14 PM" src="https://github.com/user-attachments/assets/04c3b82b-1793-4480-850b-740a8723e36d" />
