### PR TITLE
fix: Add translation comments to enhance understanding for translators

### DIFF
--- a/partials/api-key-page.php
+++ b/partials/api-key-page.php
@@ -9,7 +9,7 @@
 <h2 id="polldaddy-header"><?php esc_html_e( 'Crowdsignal', 'polldaddy' ); ?></h2>
 <p>
 	<?php
-	/* translators: name of the rating being deleted */
+	/* translators: %s is the URL to the Crowdsignal.com account details */
 	printf( __( 'Before you can use the Crowdsignal plugin, you need to enter your <a href="%s">Crowdsignal.com</a> account details.', 'polldaddy' ), 'https://crowdsignal.com/' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- fixed input
 	?>
 </p>

--- a/partials/poll-edit-form.php
+++ b/partials/poll-edit-form.php
@@ -183,12 +183,22 @@ $delete_media_link = '<a href="#" class="delete-media delete hidden" title="' . 
 					?>
 					<span style="margin:6px 6px 8px;<?php echo $poll->blockRepeatVotersType === 'off' ? 'display:none;' : ''; ?>" id="cookieip_expiration_label"><label><?php _e( 'Expires: ', 'polldaddy' ); ?></label></span>
 					<select id="cookieip_expiration" name="cookieip_expiration" style="width: auto;<?php echo $poll->blockRepeatVotersType === 'off' ? 'display:none;' : ''; ?>">
-						<option value="3600" <?php echo (int) $poll->blockExpiration === 3600 ? 'selected' : ''; ?>><?php printf( __( '%d hour', 'polldaddy' ), 1 ); ?></option>
-						<option value="10800" <?php echo (int) $poll->blockExpiration === 10800 ? 'selected' : ''; ?>><?php printf( __( '%d hours', 'polldaddy' ), 3 ); ?></option>
-						<option value="21600" <?php echo (int) $poll->blockExpiration === 21600 ? 'selected' : ''; ?>><?php printf( __( '%d hours', 'polldaddy' ), 6 ); ?></option>
+						<option value="3600" <?php echo (int) $poll->blockExpiration === 3600 ? 'selected' : ''; ?>><?php
+						/* translators: %d is the number of hours */
+						printf( __( '%d hour', 'polldaddy' ), 1 ); ?></option>
+						<option value="10800" <?php echo (int) $poll->blockExpiration === 10800 ? 'selected' : ''; ?>><?php
+						/* translators: %d is the number of hours */
+						printf( __( '%d hours', 'polldaddy' ), 3 ); ?></option>
+						<option value="21600" <?php echo (int) $poll->blockExpiration === 21600 ? 'selected' : ''; ?>><?php
+						/* translators: %d is the number of hours */
+						printf( __( '%d hours', 'polldaddy' ), 6 ); ?></option>
 						<option value="43200" <?php echo (int) $poll->blockExpiration === 43200 ? 'selected' : ''; ?>><?php printf( __( '%d hours', 'polldaddy' ), 12 ); ?></option>
-						<option value="86400" <?php echo (int) $poll->blockExpiration === 86400 ? 'selected' : ''; ?>><?php printf( __( '%d day', 'polldaddy' ), 1 ); ?></option>
-						<option value="604800" <?php echo (int) $poll->blockExpiration === 604800 ? 'selected' : ''; ?>><?php printf( __( '%d week', 'polldaddy' ), 1 ); ?></option>
+						<option value="86400" <?php echo (int) $poll->blockExpiration === 86400 ? 'selected' : ''; ?>><?php
+						/* translators: %d is the number of days */
+						printf( __( '%d day', 'polldaddy' ), 1 ); ?></option>
+						<option value="604800" <?php echo (int) $poll->blockExpiration === 604800 ? 'selected' : ''; ?>><?php
+						/* translators: %d is the number of weeks */
+						printf( __( '%d week', 'polldaddy' ), 1 ); ?></option>
 					</select>
 					<p><?php _e( 'Note: Blocking by cookie and IP address can be problematic for some voters.', 'polldaddy' ); ?></p>
 				</div>
@@ -707,8 +717,12 @@ $delete_media_link = '<a href="#" class="delete-media delete hidden" title="' . 
 					<script language="javascript">
 						jQuery( document ).ready(function(){
 							plugin = new Plugin( {
-								delete_rating: '<?php echo esc_attr( __( 'Are you sure you want to delete the rating for "%s"?', 'polldaddy' ) ); ?>',
-								delete_poll: '<?php echo esc_attr( __( 'Are you sure you want to delete "%s"?', 'polldaddy' ) ); ?>',
+								delete_rating: '<?php echo esc_attr(
+									/* translators: %s is the name of the rating being deleted */
+									__( 'Are you sure you want to delete the rating for "%s"?', 'polldaddy' ) ); ?>',
+								delete_poll: '<?php echo esc_attr(
+									/* translators: %s is the name of the poll being deleted */
+									__( 'Are you sure you want to delete "%s"?', 'polldaddy' ) ); ?>',
 								delete_answer: '<?php echo esc_attr( __( 'Are you sure you want to delete this answer?', 'polldaddy' ) ); ?>',
 								new_answer_test: '<?php echo esc_attr( __( 'Enter an answer here', 'polldaddy' ) ); ?>',
 								delete_answer_title: '<?php echo esc_attr( __( 'delete this answer', 'polldaddy' ) ); ?>',

--- a/partials/polls-table.php
+++ b/partials/polls-table.php
@@ -287,9 +287,9 @@ jQuery( document ).ready(function(){
 	const globalAccountId = '<?php echo esc_js( $global_user_id ); // phpcs:ignore -- variable comes from controller ?>';
 
 	plugin = new Plugin( {
-		<?php /* translators: name of the rating being deleted */ ?>
+		<?php /* translators: %s is the name of the rating being deleted */ ?>
 		delete_rating: '<?php echo esc_js( __( 'Are you sure you want to delete the rating for "%s"?', 'polldaddy' ) ); ?>',
-		<?php /* translators: name of the poll being deleted */ ?>
+		<?php /* translators: %s is the name of the poll being deleted */ ?>
 		delete_poll: '<?php echo esc_js( __( 'Are you sure you want to delete the poll %s?', 'polldaddy' ) ); ?>',
 		delete_answer: '<?php echo esc_js( __( 'Are you sure you want to delete this answer?', 'polldaddy' ) ); ?>',
 		delete_answer_title: '<?php echo esc_js( __( 'delete this answer', 'polldaddy' ) ); ?>',

--- a/polldaddy-org.php
+++ b/polldaddy-org.php
@@ -652,7 +652,9 @@ function polldaddy_login_warning() {
 		return;
 	}
 
-	echo '<div class="updated"><p><strong>' . sprintf( __( 'Crowdsignal features will be unavailable until you link your Crowdsignal.com account. Please visit the <a href="%s">plugin settings page</a> to login.', 'polldaddy' ), admin_url( 'options-general.php?page=crowdsignal-settings' ) ) . '</strong></p></div>';
+	echo '<div class="updated"><p><strong>' . sprintf(
+		/* translators: %s is the URL to the plugin settings page */
+		__( 'Crowdsignal features will be unavailable until you link your Crowdsignal.com account. Please visit the <a href="%s">plugin settings page</a> to login.', 'polldaddy' ), admin_url( 'options-general.php?page=crowdsignal-settings' ) ) . '</strong></p></div>';
 }
 add_action( 'admin_notices', 'polldaddy_login_warning' );
 

--- a/polldaddy.php
+++ b/polldaddy.php
@@ -202,8 +202,7 @@ class WP_Polldaddy {
 
 		// Add settings pages.
 		foreach( array( 'crowdsignal-settings' => __( 'Crowdsignal', 'polldaddy' ), 'ratingsettings' => __( 'Ratings', 'polldaddy' ) ) as $menu_slug => $page_title ) {
-			// translators: %s placeholder is the setting page type (Poll or Rating).
-			$settings_page_title = sprintf( esc_html__( '%s', 'polldaddy' ), $page_title );
+			$settings_page_title = sprintf( esc_html( $page_title ) );
 			$hook = add_options_page( $settings_page_title, $settings_page_title, $menu_slug == 'ratingsettings' ? 'manage_options' : 'edit_others_posts', $menu_slug, array( $this, 'settings_page' ) );
 			add_action( "load-$hook", array( $this, 'management_page_load' ) );
 		}
@@ -1592,7 +1591,9 @@ class WP_Polldaddy {
 					if ( 1 == $deleted ) {
 						$message = __( 'Poll deleted.', 'polldaddy' );
 					} else {
-						$message = sprintf( _n( '%s Poll Deleted.', '%s Polls Deleted.', $deleted, 'polldaddy' ), number_format_i18n( $deleted ) );
+						$message = sprintf(
+							/* translators: %s is the number of polls deleted */
+							_n( '%s Poll Deleted.', '%s Polls Deleted.', $deleted, 'polldaddy' ), number_format_i18n( $deleted ) );
 					}
 					break;
 				case 'opened' :
@@ -1600,7 +1601,9 @@ class WP_Polldaddy {
 					if ( 1 == $opened ) {
 						$message = __( 'Poll opened.', 'polldaddy' );
 					} else {
-						$message = sprintf( _n( '%s Poll Opened.', '%s Polls Opened.', $opened, 'polldaddy' ), number_format_i18n( $opened ) );
+						$message = sprintf(
+							/* translators: %s is the number of polls opened */
+							_n( '%s Poll Opened.', '%s Polls Opened.', $opened, 'polldaddy' ), number_format_i18n( $opened ) );
 					}
 					break;
 				case 'closed' :
@@ -1608,7 +1611,9 @@ class WP_Polldaddy {
 					if ( 1 == $closed ) {
 						$message = __( 'Poll closed.', 'polldaddy' );
 					} else {
-						$message = sprintf( _n( '%s Poll Closed.', '%s Polls Closed.', $closed, 'polldaddy' ), number_format_i18n( $closed ) );
+						$message = sprintf(
+							/* translators: %s is the number of polls closed */
+							_n( '%s Poll Closed.', '%s Polls Closed.', $closed, 'polldaddy' ), number_format_i18n( $closed ) );
 					}
 					break;
 				case 'updated' :
@@ -1631,7 +1636,9 @@ class WP_Polldaddy {
 					if ( 1 == $deleted ) {
 						$message = __( 'Custom Style deleted.', 'polldaddy' );
 					} else {
-						$message = sprintf( _n( '%s Style Deleted.', '%s Custom Styles Deleted.', $deleted, 'polldaddy' ), number_format_i18n( $deleted ) );
+						$message = sprintf(
+							/* translators: %s is the number of styles deleted */
+							_n( '%s Style Deleted.', '%s Custom Styles Deleted.', $deleted, 'polldaddy' ), number_format_i18n( $deleted ) );
 					}
 					break;
 				case 'connected' :
@@ -1649,7 +1656,9 @@ class WP_Polldaddy {
 					if ( 1 == $deleted ) {
 						$message = __( 'Rating deleted.', 'polldaddy' );
 					} else {
-						$message = sprintf( _n( '%s Rating Deleted.', '%s Ratings Deleted.', $deleted, 'polldaddy' ), number_format_i18n( $deleted ) );
+						$message = sprintf(
+							/* translators: %s is the number of ratings deleted */
+							_n( '%s Rating Deleted.', '%s Ratings Deleted.', $deleted, 'polldaddy' ), number_format_i18n( $deleted ) );
 					}
 					break;
 			}//end switch
@@ -1732,7 +1741,9 @@ class WP_Polldaddy {
 							if ( isset( $_GET['iframe'] ) ) {
 								if ( isset( $_GET['popup'] ) ) {
 									?>
-									<h2 id="poll-list-header"><?php printf( __( 'Preview Poll <a href="%s" class="add-new-h2">All Polls</a>', 'polldaddy' ), esc_url( add_query_arg( array( 'action' => 'polls', 'poll' => false, 'message' => false ) ) ) ); ?></h2>
+									<h2 id="poll-list-header"><?php
+									/* translators: %s is the URL to all polls */
+									printf( __( 'Preview Poll <a href="%s" class="add-new-h2">All Polls</a>', 'polldaddy' ), esc_url( add_query_arg( array( 'action' => 'polls', 'poll' => false, 'message' => false ) ) ) ); ?></h2>
 									<?php
 								}
 							}
@@ -1744,7 +1755,9 @@ class WP_Polldaddy {
 						case 'results':
 							?>
 							<h2 id="poll-list-header">
-								<?php printf( __( 'Poll Results <a href="%s" class="add-new-h2">All Polls</a> <a href="%s" class="add-new-h2">Edit Poll</a>', 'polldaddy' ), esc_url( add_query_arg( array( 'action' => 'polls', 'poll' => false, 'message' => false ) ) ), esc_url( add_query_arg( array( 'action' => 'edit-poll', 'poll' => $poll, 'message' => false ) ) ) ); ?>
+								<?php
+								/* translators: %s is the URL to all polls, %s is the URL to edit poll */
+								printf( __( 'Poll Results <a href="%1$s" class="add-new-h2">All Polls</a> <a href="%2$s" class="add-new-h2">Edit Poll</a>', 'polldaddy' ), esc_url( add_query_arg( array( 'action' => 'polls', 'poll' => false, 'message' => false ) ) ), esc_url( add_query_arg( array( 'action' => 'edit-poll', 'poll' => $poll, 'message' => false ) ) ) ); ?>
 							</h2>
 							<?php
 							$this->poll_results_page( $poll );
@@ -1755,7 +1768,8 @@ class WP_Polldaddy {
 							<h2 id="poll-list-header">
 								<?php
 								printf(
-									__( 'Edit Poll <a href="%s" class="add-new-h2">All Polls</a> <a href="%s" class="add-new-h2">View Results</a>', 'polldaddy' ),
+									/* translators: %s is the URL to all polls, %s is the URL to view results */
+									__( 'Edit Poll <a href="%1$s" class="add-new-h2">All Polls</a> <a href="%2$s" class="add-new-h2">View Results</a>', 'polldaddy' ),
 									esc_url( add_query_arg( array( 'action' => 'polls', 'poll' => false, 'message' => false ) ) ),
 									esc_url( add_query_arg( array( 'action' => 'results', 'poll' => $poll, 'message' => false ) ) )
 								);
@@ -1767,7 +1781,9 @@ class WP_Polldaddy {
 							break;
 						case 'create-poll':
 							?>
-							<h2 id="poll-list-header"><?php printf( __( 'Add New Poll <a href="%s" class="add-new-h2">All Polls</a>', 'polldaddy' ), esc_url( add_query_arg( array( 'action' => 'polls', 'poll' => false, 'message' => false ) ) ) ); ?></h2>
+							<h2 id="poll-list-header"><?php
+							/* translators: %s is the URL to all polls */
+							printf( __( 'Add New Poll <a href="%s" class="add-new-h2">All Polls</a>', 'polldaddy' ), esc_url( add_query_arg( array( 'action' => 'polls', 'poll' => false, 'message' => false ) ) ) ); ?></h2>
 							<?php
 							$this->poll_edit_form();
 							break;
@@ -1775,10 +1791,12 @@ class WP_Polldaddy {
 							?>
 							<h2 id="polldaddy-header">
 								<?php
-								if ( $this->is_author )
+								if ( $this->is_author ) {
+									/* translators: %s is the URL to add new style */
 									printf( __( 'Custom Styles <a href="%s" class="add-new-h2">Add New</a>', 'polldaddy' ), esc_url( add_query_arg( array( 'action' => 'create-style', 'poll' => false, 'message' => false ) ) ) );
-								else
+								} else {
 									_e( 'Custom Styles', 'polldaddy' );
+								}
 								?>
 							</h2>
 							<?php
@@ -1787,7 +1805,9 @@ class WP_Polldaddy {
 						case 'edit-style':
 							?>
 							<h2 id="polldaddy-header">
-								<?php printf( __( 'Edit Style <a href="%s" class="add-new-h2">List Styles</a>', 'polldaddy' ), esc_url( add_query_arg( array( 'action' => 'list-styles', 'style' => false, 'message' => false, 'preload' => false ) ) ) ); ?>
+								<?php
+								/* translators: %s is the URL to list styles */
+								printf( __( 'Edit Style <a href="%s" class="add-new-h2">List Styles</a>', 'polldaddy' ), esc_url( add_query_arg( array( 'action' => 'list-styles', 'style' => false, 'message' => false, 'preload' => false ) ) ) ); ?>
 							</h2>
 							<?php
 
@@ -1796,7 +1816,9 @@ class WP_Polldaddy {
 						case 'create-style':
 							?>
 							<h2 id="polldaddy-header">
-								<?php printf( __( 'Create Style <a href="%s" class="add-new-h2">List Styles</a>', 'polldaddy' ), esc_url( add_query_arg( array( 'action' => 'list-styles', 'style' => false, 'message' => false, 'preload' => false ) ) ) ); ?>
+								<?php
+								/* translators: %s is the URL to list styles */
+								printf( __( 'Create Style <a href="%s" class="add-new-h2">List Styles</a>', 'polldaddy' ), esc_url( add_query_arg( array( 'action' => 'list-styles', 'style' => false, 'message' => false, 'preload' => false ) ) ) ); ?>
 							</h2>
 							<?php
 							$this->style_edit_form();
@@ -2126,6 +2148,7 @@ class WP_Polldaddy {
 		}
 
 		$class = $class ? '' : ' class="alternate"';
+		/* translators: %s is the URL to other answers results */
 		$content = $results->others && 'Other answer…' === $answer->text ? sprintf( __( 'Other (<a href="%s">see below</a>)', 'polldaddy' ), '#other-answers-results' ) : esc_html( $answer->text );
 
 ?>
@@ -3139,7 +3162,9 @@ class WP_Polldaddy {
 																<label class="pds-feedback-label" id="pds-feedback-label">
 																	<span class="pds-answer-text" id="pds-answer-text"><?php _e( 'I use it in school!', 'polldaddy' ); ?></span>
 																	<span class="pds-feedback-result" id="pds-feedback-result">
-																		<span class="pds-feedback-per" id="pds-feedback-per">&nbsp;46%</span>&nbsp;<span class="pds-feedback-votes" id="pds-feedback-votes"> <?php printf( __( '(%d votes)', 'polldaddy' ), 620 ); ?></span>
+																		<span class="pds-feedback-per" id="pds-feedback-per">&nbsp;46%</span>&nbsp;<span class="pds-feedback-votes" id="pds-feedback-votes"> <?php
+																		/* translators: %d is the number of votes */
+																		printf( __( '(%d votes)', 'polldaddy' ), 620 ); ?></span>
 																	</span>
 																</label>
 																<span style="display: block;clear: both;height:1px;line-height:1px;" class="pds-clear">&nbsp;</span>
@@ -3590,7 +3615,11 @@ class WP_Polldaddy {
 		$previous_settings = get_option( 'polldaddy_settings' );
 		$current_setting   = get_option( 'pd-rating-posts-id' );
 		if ( $current_setting && isset( $previous_settings[ 'pd-rating-posts-id' ] ) && $current_setting != $previous_settings[ 'pd-rating-posts-id' ] ) {
-			echo "<p>" . sprintf( __( "Previous settings for ratings on this site discovered. You can restore them on the <a href='%s'>poll settings page</a> if your site is missing ratings after resetting your connection settings.", 'polldaddy' ), "options-general.php?page=crowdsignal-settings" ) . "</p>";
+			echo "<p>" . sprintf(
+				/* translators: %s is the URL to Crowdsignal settings page */
+				__( "Previous settings for ratings on this site discovered. You can restore them on the <a href='%s'>poll settings page</a> if your site is missing ratings after resetting your connection settings.", 'polldaddy' ), 
+				"options-general.php?page=crowdsignal-settings" 
+			) . "</p>";
 		}
 		?>
         </div>
@@ -3662,13 +3691,17 @@ class WP_Polldaddy {
                     <td><input onblur="pd_bind(this);" type="text" style="width: 100%;" name="text_rate_this" id="text_rate_this" value="<?php echo empty( $settings->text_rate_this ) ? 'Rate This' : esc_html( $settings->text_rate_this ); ?>" maxlength="20" />
                   </tr>
                   <tr>
-                    <td><p style="margin-bottom: 0px;"><?php printf( __( '%d star', 'polldaddy' ), 1 );?></p></td>
+                    <td><p style="margin-bottom: 0px;"><?php
+					/* translators: %d is the number of stars */
+					printf( __( '%d star', 'polldaddy' ), 1 );?></p></td>
                   </tr>
                   <tr>
                     <td><input onblur="pd_bind(this);" type="text" style="width: 100%;" name="text_1_star" id="text_1_star" value="<?php echo empty( $settings->text_1_star ) ? '1 star' : esc_html( $settings->text_1_star ); ?>" maxlength="20" />
                   </tr>
                   <tr>
-                    <td><p style="margin-bottom: 0px;"><?php printf( __( '%d stars', 'polldaddy' ), 2 );?></p></td>
+                    <td><p style="margin-bottom: 0px;"><?php
+					/* translators: %d is the number of stars */
+					printf( __( '%d stars', 'polldaddy' ), 2 );?></p></td>
                   </tr>
                   <tr>
                     <td><input onblur="pd_bind(this);" type="text" style="width: 100%;" name="text_2_star" id="text_2_star" value="<?php echo empty( $settings->text_2_star ) ? '2 stars' : esc_html( $settings->text_2_star ); ?>" maxlength="20" />
@@ -3773,7 +3806,9 @@ class WP_Polldaddy {
 				if ( $settings->type == 'stars' )
 					$checked = ' checked="checked"';?>
                         <input type="radio" onchange="pd_change_type( 0 );" <?php echo $checked; ?> value="stars" id="stars" name="rating_type" />
-                          <?php printf( __( '%d Star Rating', 'polldaddy' ), 5 );?>
+                          <?php
+						  /* translators: %d is the number of stars */
+						  printf( __( '%d Star Rating', 'polldaddy' ), 5 );?>
                         </label>
                     </li>
                     <li style="display: inline;">
@@ -4300,7 +4335,9 @@ class WP_Polldaddy {
 ?>
 		<div class="wrap">
 			<?php if ( $this->is_admin ) : ?>
-			<h2 id="polldaddy-header"><?php printf( __( 'Rating Results <a href="%s" class="add-new-h2">Settings</a>', 'polldaddy' ), esc_url( 'options-general.php?page=ratingsettings' ) ); ?></h2>
+			<h2 id="polldaddy-header"><?php
+				/* translators: %s is the URL to Crowdsignal settings page */
+				printf( __( 'Rating Results <a href="%s" class="add-new-h2">Settings</a>', 'polldaddy' ), esc_url( 'options-general.php?page=ratingsettings' ) ); ?></h2>
 			<?php else : ?>
 			<h2 id="polldaddy-header"><?php _e( 'Rating Results', 'polldaddy' ); ?></h2>
 			<?php endif; ?>
@@ -4355,7 +4392,9 @@ class WP_Polldaddy {
 		if ( empty( $ratings ) ) { ?>
 				<tbody>
 					<tr>
-						<td colspan="4"><?php printf( __( 'No ratings have been collected for your %s yet.', 'polldaddy' ), $report_type ); ?></td>
+						<td colspan="4"><?php
+						/* translators: %s is the report type */
+						printf( __( 'No ratings have been collected for your %s yet.', 'polldaddy' ), $report_type ); ?></td>
 					</tr>
 				</tbody><?php
 		} else {
@@ -4622,7 +4661,9 @@ class WP_Polldaddy {
 		echo '<h1>' . $message . '</h1>';
 		echo '<p>' . __( "There are a few things you can do:" );
 		echo "<ul><ol>" . __( "Press reload on your browser and reload this page. There may have been a temporary problem communicating with Crowdsignal.com", "polldaddy" ) . "</ol>";
+		/* translators: %1$s is the URL to Crowdsignal settings page */
 		echo "<ol>" . sprintf( __( "Go to the <a href='%s'>poll settings page</a>, scroll to the end of the page and reset your connection settings. Link your account again with the same API key.", "polldaddy" ), 'options-general.php?page=crowdsignal-settings' ) . "</ol>";
+		/* translators: %1$s is the URL to Crowdsignal support, %2$s is the target attribute, %3$s is the rating usercode */
 		echo "<ol>" . sprintf( __( 'Contact <a href="%1$s" %2$s>Crowdsignal support</a> and tell them your rating usercode is %3$s', 'polldaddy' ), 'https://crowdsignal.com/feedback/', 'target="_blank"', $this->rating_user_code ) . '<br />' . __( 'Also include the following information when contacting support to help us resolve your problem as quickly as possible:', 'polldaddy' ) . '';
 		echo "<ul><li> API Key: " . get_option( 'polldaddy_api_key' ) . "</li>";
 		echo "<li> ID Usercode: " . get_option( 'pd-usercode-' . $current_user->ID ) . "</li>";

--- a/popups.php
+++ b/popups.php
@@ -17,9 +17,24 @@ function pd_video_shortcodes_help($video_form) {
 			<td colspan="2">
 				<p>' . __('Paste your YouTube or Google Video URL above, or use the examples below.', 'polldaddy') . '</p>
 				<ul class="short-code-list">
-					<li>' . sprintf( __('<a href="%s" target="_blank">YouTube instructions</a> %s', 'polldaddy'), 'http://support.wordpress.com/videos/youtube/', '<code>[youtube=http://www.youtube.com/watch?v=cXXm696UbKY]</code>' )  .'</li>
-					<li>' . sprintf( __('<a href="%s" target="_blank">Google instructions</a> %s', 'polldaddy') , 'http://support.wordpress.com/videos/google-video/', '<code>[googlevideo=http://video.google.com/googleplayer.swf?docId=-8459301055248673864]</code>' ) . '</li>
-					<li>' . sprintf( __('<a href="%s" target="_blank">DailyMotion instructions</a> %s', 'polldaddy'), 'http://support.wordpress.com/videos/dailymotion/', '<code>[dailymotion id=5zYRy1JLhuGlP3BGw]</code>' ) . '</li>
+					<li>' . sprintf( 
+						/* translators: %1$s is the URL to YouTube instructions, %2$s is the example shortcode */
+						__('<a href="%1$s" target="_blank">YouTube instructions</a> %2$s', 'polldaddy'), 
+						'http://support.wordpress.com/videos/youtube/', 
+						'<code>[youtube=http://www.youtube.com/watch?v=cXXm696UbKY]</code>' 
+					) . '</li>
+					<li>' . sprintf( 
+						/* translators: %1$s is the URL to Google Video instructions, %2$s is the example shortcode */
+						__('<a href="%1$s" target="_blank">Google instructions</a> %2$s', 'polldaddy'), 
+						'http://support.wordpress.com/videos/google-video/', 
+						'<code>[googlevideo=http://video.google.com/googleplayer.swf?docId=-8459301055248673864]</code>' 
+					) . '</li>
+					<li>' . sprintf( 
+						/* translators: %1$s is the URL to DailyMotion instructions, %2$s is the example shortcode */
+						__('<a href="%1$s" target="_blank">DailyMotion instructions</a> %2$s', 'polldaddy'), 
+						'http://support.wordpress.com/videos/dailymotion/', 
+						'<code>[dailymotion id=5zYRy1JLhuGlP3BGw]</code>' 
+					) . '</li>
 				</ul>
 			</td>
 		</tr>


### PR DESCRIPTION
Fixes #120

## Changes proposed in this Pull Request

Add translator comments for string placeholders.

## Testing instructions

No changes visually. Using a tool like POEdit will now show the translator comments. Running `wp i18n make-pot . languages/polldaddy.po` will no longer generate a list of issues.

<!-- Add the following only if this is meant to be in changelog -->
## Proposed changelog entry for your changes

fix: Add translation comments to enhance understanding for translators.