### PR TITLE
refactor: Remove makepot task and update build script for i18n

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -39,30 +39,6 @@ module.exports = function( grunt ){
         watch: {
         },
 
-        // Generate POT files.
-        makepot: {
-            options: {
-                type: 'wp-plugin',
-                domainPath: '/locale',
-                potHeaders: {
-                    'report-msgid-bugs-to': 'https://github.com/Automattic/polldaddy-plugin/issues',
-                    'language-team': 'LANGUAGE <EMAIL@ADDRESS>'
-                }
-            },
-            dist: {
-                options: {
-                    potFilename: 'polldaddy.pot',
-                    exclude: [
-                        'apigen/.*',
-                        'tests/.*',
-                        'tmp/.*',
-                        'vendor/.*',
-                        'node_modules/.*'
-                    ]
-                }
-            }
-        },
-
         // Check textdomain errors.
         checktextdomain: {
             options:{
@@ -160,7 +136,7 @@ module.exports = function( grunt ){
     grunt.loadNpmTasks( 'grunt-checkbranch' );
     grunt.loadNpmTasks( 'grunt-wp-deploy' );
     grunt.loadNpmTasks( 'grunt-shell' );
-    grunt.loadNpmTasks( 'grunt-wp-i18n' );
+    grunt.loadNpmTasks( 'grunt-wp-i18n' ); // Needed for addtextdomain task.
     grunt.loadNpmTasks( 'grunt-wp-readme-to-markdown');
     grunt.loadNpmTasks( 'grunt-zip' );
 
@@ -179,8 +155,4 @@ module.exports = function( grunt ){
         'wp_readme_to_markdown'
     ] );
 
-    // Just an alias for pot file generation
-    grunt.registerTask( 'pot', [
-        'makepot'
-    ] );
 };

--- a/locale/polldaddy.pot
+++ b/locale/polldaddy.pot
@@ -1,65 +1,110 @@
-# Copyright (C) 2024 Automattic, Inc.
-# This file is distributed under the same license as the Crowdsignal Polls & Ratings package.
+# Copyright (C) 2025 Automattic, Inc.
+# This file is distributed under the same license as the Crowdsignal Polls & Ratings plugin.
 msgid ""
 msgstr ""
 "Project-Id-Version: Crowdsignal Polls & Ratings 3.1.2\n"
-"Report-Msgid-Bugs-To: https://github.com/Automattic/polldaddy-plugin/issues\n"
-"POT-Creation-Date: 2024-07-30 14:03:41+00:00\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2024-MO-DA HO:MI+ZONE\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/crowdsignal-plugin\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
-"X-Generator: grunt-wp-i18n 1.0.3\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2025-09-24T10:44:44+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"X-Generator: WP-CLI 2.12.0\n"
+"X-Domain: polldaddy\n"
 
-#: ajax.php:80 partials/poll-edit-form.php:310 partials/poll-edit-form.php:373
-#: partials/poll-edit-form.php:715
+#. Plugin Name of the plugin
+#: polldaddy.php
+msgid "Crowdsignal Polls & Ratings"
+msgstr ""
+
+#. Plugin URI of the plugin
+#: polldaddy.php
+msgid "https://wordpress.org/plugins/polldaddy/"
+msgstr ""
+
+#. Description of the plugin
+#: polldaddy.php
+msgid "Create and manage Crowdsignal polls and ratings in WordPress"
+msgstr ""
+
+#. Author of the plugin
+#: polldaddy.php
+msgid "Automattic, Inc."
+msgstr ""
+
+#: ajax.php:80
+#: partials/poll-edit-form.php:320
+#: partials/poll-edit-form.php:383
+#: partials/poll-edit-form.php:729
 msgid "click and drag to reorder"
 msgstr ""
 
-#: ajax.php:83 partials/poll-edit-form.php:313 partials/poll-edit-form.php:376
-#: partials/poll-edit-form.php:713
+#: ajax.php:83
+#: partials/poll-edit-form.php:323
+#: partials/poll-edit-form.php:386
+#: partials/poll-edit-form.php:727
 msgid "Enter an answer here"
 msgstr ""
 
-#: ajax.php:97 partials/poll-edit-form.php:263 partials/poll-edit-form.php:341
-#: partials/poll-edit-form.php:382 partials/poll-edit-form.php:716
+#: ajax.php:97
+#: partials/poll-edit-form.php:273
+#: partials/poll-edit-form.php:351
+#: partials/poll-edit-form.php:392
+#: partials/poll-edit-form.php:730
 msgid "Add an Image"
 msgstr ""
 
-#: ajax.php:98 partials/poll-edit-form.php:264 partials/poll-edit-form.php:342
-#: partials/poll-edit-form.php:383 partials/poll-edit-form.php:717
+#: ajax.php:98
+#: partials/poll-edit-form.php:274
+#: partials/poll-edit-form.php:352
+#: partials/poll-edit-form.php:393
+#: partials/poll-edit-form.php:731
 msgid "Add Audio"
 msgstr ""
 
-#: ajax.php:99 partials/poll-edit-form.php:265 partials/poll-edit-form.php:343
-#: partials/poll-edit-form.php:384 partials/poll-edit-form.php:718
+#: ajax.php:99
+#: partials/poll-edit-form.php:275
+#: partials/poll-edit-form.php:353
+#: partials/poll-edit-form.php:394
+#: partials/poll-edit-form.php:732
 msgid "Add Video"
 msgstr ""
 
-#: partials/api-key-page.php:9 partials/crowdsignal-landing-page.php:15
-#: partials/crowdsignal-landing-page.php:28 partials/polls-table.php:15
-#: polldaddy.php:196 polldaddy.php:204 polldaddy.php:360
+#: partials/api-key-page.php:9
+#: partials/crowdsignal-landing-page.php:15
+#: partials/crowdsignal-landing-page.php:28
+#: partials/polls-table.php:15
+#: polldaddy.php:198
+#: polldaddy.php:206
+#: polldaddy.php:361
 msgid "Crowdsignal"
 msgstr ""
 
-#: partials/api-key-page.php:13 polldaddy-org.php:263 polldaddy.php:362
-#. translators: name of the rating being deleted
-msgid ""
-"Before you can use the Crowdsignal plugin, you need to enter your <a "
-"href=\"%s\">Crowdsignal.com</a> account details."
+#. translators: %s is the URL to the Crowdsignal.com account details
+#: partials/api-key-page.php:13
+#: polldaddy-org.php:263
+#: polldaddy.php:363
+#, php-format
+msgid "Before you can use the Crowdsignal plugin, you need to enter your <a href=\"%s\">Crowdsignal.com</a> account details."
 msgstr ""
 
-#: partials/api-key-page.php:22 polldaddy-org.php:270 polldaddy.php:369
+#: partials/api-key-page.php:22
+#: polldaddy-org.php:270
+#: polldaddy.php:370
 msgid "Crowdsignal Email Address"
 msgstr ""
 
-#: partials/api-key-page.php:30 polldaddy-org.php:278 polldaddy.php:377
+#: partials/api-key-page.php:30
+#: polldaddy-org.php:278
+#: polldaddy.php:378
 msgid "Crowdsignal Password"
 msgstr ""
 
-#: partials/api-key-page.php:42 polldaddy-org.php:305 polldaddy.php:389
+#: partials/api-key-page.php:42
+#: polldaddy-org.php:305
+#: polldaddy.php:390
 msgid "Submit"
 msgstr ""
 
@@ -72,9 +117,7 @@ msgid "Start asking!"
 msgstr ""
 
 #: partials/crowdsignal-landing-page.php:29
-msgid ""
-"is a collection of powerful blocks that help you to collect feedback, "
-"analyze incoming responses and learn from your audience."
+msgid "is a collection of powerful blocks that help you to collect feedback, analyze incoming responses and learn from your audience."
 msgstr ""
 
 #: partials/crowdsignal-landing-page.php:44
@@ -114,9 +157,7 @@ msgid "Survey Embed"
 msgstr ""
 
 #: partials/crowdsignal-landing-page.php:71
-msgid ""
-"Create surveys in minutes with 14 question and form types and embed them "
-"into your page."
+msgid "Create surveys in minutes with 14 question and form types and embed them into your page."
 msgstr ""
 
 #: partials/crowdsignal-landing-page.php:78
@@ -132,9 +173,7 @@ msgid "Feedback Button"
 msgstr ""
 
 #: partials/crowdsignal-landing-page.php:82
-msgid ""
-"A floating always visible button that allows your audience to share "
-"feedback anytime."
+msgid "A floating always visible button that allows your audience to share feedback anytime."
 msgstr ""
 
 #: partials/crowdsignal-landing-page.php:88
@@ -150,9 +189,7 @@ msgid "Measure NPS"
 msgstr ""
 
 #: partials/crowdsignal-landing-page.php:92
-msgid ""
-"Calculate your Net Promoter Score! Collect feedback and track customer "
-"satisfaction over time."
+msgid "Calculate your Net Promoter Score! Collect feedback and track customer satisfaction over time."
 msgstr ""
 
 #: partials/crowdsignal-landing-page.php:99
@@ -264,36 +301,29 @@ msgstr ""
 msgid "You're ready to start using Crowdsignal!"
 msgstr ""
 
-#: partials/html-admin-setup-step-3.php:22 partials/html-admin-teaser.php:22
+#: partials/html-admin-setup-step-3.php:22
+#: partials/html-admin-teaser.php:22
 msgid "First time using Crowdsignal?"
 msgstr ""
 
 #: partials/html-admin-setup-step-3.php:25
-msgid ""
-"You can use Crowdsignal blocks right in your editor. Search for Crowdsignal "
-"in the blocks library and add the blocks to your page. Here is a short "
-"video to get you started:"
+msgid "You can use Crowdsignal blocks right in your editor. Search for Crowdsignal in the blocks library and add the blocks to your page. Here is a short video to get you started:"
 msgstr ""
 
-#: partials/html-admin-setup-step-3.php:38
 #. translators: Argument is a link to Crowdsignal's support page.
-msgid ""
-"Do you want to know more about Crowdsignal and our blocks? <a href=\"%1s\" "
-"target=\"_blank\">Learn more</a>."
+#: partials/html-admin-setup-step-3.php:38
+#, php-format
+msgid "Do you want to know more about Crowdsignal and our blocks? <a href=\"%1s\" target=\"_blank\">Learn more</a>."
 msgstr ""
 
 #: partials/html-admin-teaser.php:16
 msgid "Crowdsignal Blocks"
 msgstr ""
 
+#. translators: Placeholder is the text "second plugin" and "Install the plugin".
 #: partials/html-admin-teaser.php:28
-#. translators: Placeholder is the text "second plugin" and "Install the
-#. plugin".
-msgid ""
-"We have a %1$s called Crowdsignal Forms that allows you to create "
-"Crowdsignal blocks right inside of your WordPress editor. %2$s, then search "
-"for Crowdsignal in the blocks library and add Crowdsignal blocks, like a "
-"Poll block or Feedback button."
+#, php-format
+msgid "We have a %1$s called Crowdsignal Forms that allows you to create Crowdsignal blocks right inside of your WordPress editor. %2$s, then search for Crowdsignal in the blocks library and add Crowdsignal blocks, like a Poll block or Feedback button."
 msgstr ""
 
 #: partials/html-admin-teaser.php:31
@@ -312,8 +342,9 @@ msgstr ""
 msgid "See an overview of our Crowdsignal blocks."
 msgstr ""
 
-#: partials/html-admin-teaser.php:67
 #. translators: Placeholder is the text "website plugins page".
+#: partials/html-admin-teaser.php:67
+#, php-format
 msgid "Install the Crowdsignal Forms plugin directly from your %s."
 msgstr ""
 
@@ -325,7 +356,8 @@ msgstr ""
 msgid "delete this image"
 msgstr ""
 
-#: partials/poll-edit-form.php:40 partials/settings-2.php:36
+#: partials/poll-edit-form.php:40
+#: partials/settings-2.php:36
 msgid "Save"
 msgstr ""
 
@@ -357,7 +389,8 @@ msgstr ""
 msgid "Save Poll"
 msgstr ""
 
-#: partials/poll-edit-form.php:109 polldaddy.php:1620
+#: partials/poll-edit-form.php:109
+#: polldaddy.php:1627
 msgid "Embed in Post"
 msgstr ""
 
@@ -397,466 +430,566 @@ msgstr ""
 msgid "Expires: "
 msgstr ""
 
-#: partials/poll-edit-form.php:186
+#. translators: %d is the number of hours
+#: partials/poll-edit-form.php:188
+#, php-format
 msgid "%d hour"
 msgstr ""
 
-#: partials/poll-edit-form.php:187 partials/poll-edit-form.php:188
-#: partials/poll-edit-form.php:189
+#. translators: %d is the number of hours
+#: partials/poll-edit-form.php:191
+#: partials/poll-edit-form.php:194
+#: partials/poll-edit-form.php:195
+#, php-format
 msgid "%d hours"
 msgstr ""
 
-#: partials/poll-edit-form.php:190
+#. translators: %d is the number of days
+#: partials/poll-edit-form.php:198
+#, php-format
 msgid "%d day"
 msgstr ""
 
-#: partials/poll-edit-form.php:191
+#. translators: %d is the number of weeks
+#: partials/poll-edit-form.php:201
+#, php-format
 msgid "%d week"
 msgstr ""
 
-#: partials/poll-edit-form.php:193
+#: partials/poll-edit-form.php:203
 msgid "Note: Blocking by cookie and IP address can be problematic for some voters."
 msgstr ""
 
-#: partials/poll-edit-form.php:198 polldaddy.php:3204 polldaddy.php:3494
-#: polldaddy.php:3565 polldaddy.php:4321
+#: partials/poll-edit-form.php:208
+#: polldaddy.php:3231
+#: polldaddy.php:3521
+#: polldaddy.php:3592
+#: polldaddy.php:4360
 msgid "Comments"
 msgstr ""
 
-#: partials/poll-edit-form.php:204
+#: partials/poll-edit-form.php:214
 msgid "Allow comments"
 msgstr ""
 
-#: partials/poll-edit-form.php:205
+#: partials/poll-edit-form.php:215
 msgid "Moderate first"
 msgstr ""
 
-#: partials/poll-edit-form.php:206
+#: partials/poll-edit-form.php:216
 msgid "No comments"
 msgstr ""
 
-#: partials/poll-edit-form.php:238
+#: partials/poll-edit-form.php:248
 msgid "Enter Question Here"
 msgstr ""
 
-#: partials/poll-edit-form.php:279
+#: partials/poll-edit-form.php:289
 msgid "WordPress Shortcode:"
 msgstr ""
 
-#: partials/poll-edit-form.php:281
+#: partials/poll-edit-form.php:291
 msgid "Embed Poll in New Post"
 msgstr ""
 
-#: partials/poll-edit-form.php:290 polldaddy.php:2405
+#: partials/poll-edit-form.php:300
+#: polldaddy.php:2430
 msgid "Answers"
 msgstr ""
 
-#: partials/poll-edit-form.php:346 partials/poll-edit-form.php:386
-#: partials/poll-edit-form.php:714 partials/polls-table.php:295
-#: polldaddy.php:3242 polldaddy.php:4028 polldaddy.php:4451
+#: partials/poll-edit-form.php:356
+#: partials/poll-edit-form.php:396
+#: partials/poll-edit-form.php:728
+#: partials/polls-table.php:295
+#: polldaddy.php:3269
+#: polldaddy.php:4065
+#: polldaddy.php:4492
 msgid "delete this answer"
 msgstr ""
 
-#: partials/poll-edit-form.php:404
+#: partials/poll-edit-form.php:414
 msgid "Add New Answer"
 msgstr ""
 
-#: partials/poll-edit-form.php:425 polldaddy.php:4477
+#: partials/poll-edit-form.php:435
+#: polldaddy.php:4518
 msgid "Aluminum Narrow"
 msgstr ""
 
-#: partials/poll-edit-form.php:426 polldaddy.php:4478
+#: partials/poll-edit-form.php:436
+#: polldaddy.php:4519
 msgid "Aluminum Medium"
 msgstr ""
 
-#: partials/poll-edit-form.php:427 polldaddy.php:4479
+#: partials/poll-edit-form.php:437
+#: polldaddy.php:4520
 msgid "Aluminum Wide"
 msgstr ""
 
-#: partials/poll-edit-form.php:428 polldaddy.php:4480
+#: partials/poll-edit-form.php:438
+#: polldaddy.php:4521
 msgid "Plain White Narrow"
 msgstr ""
 
-#: partials/poll-edit-form.php:429 polldaddy.php:4481
+#: partials/poll-edit-form.php:439
+#: polldaddy.php:4522
 msgid "Plain White Medium"
 msgstr ""
 
-#: partials/poll-edit-form.php:430 polldaddy.php:4482
+#: partials/poll-edit-form.php:440
+#: polldaddy.php:4523
 msgid "Plain White Wide"
 msgstr ""
 
-#: partials/poll-edit-form.php:431 polldaddy.php:4483
+#: partials/poll-edit-form.php:441
+#: polldaddy.php:4524
 msgid "Plain Black Narrow"
 msgstr ""
 
-#: partials/poll-edit-form.php:432 polldaddy.php:4484
+#: partials/poll-edit-form.php:442
+#: polldaddy.php:4525
 msgid "Plain Black Medium"
 msgstr ""
 
-#: partials/poll-edit-form.php:433 polldaddy.php:4485
+#: partials/poll-edit-form.php:443
+#: polldaddy.php:4526
 msgid "Plain Black Wide"
 msgstr ""
 
-#: partials/poll-edit-form.php:434 polldaddy.php:4486
+#: partials/poll-edit-form.php:444
+#: polldaddy.php:4527
 msgid "Paper Narrow"
 msgstr ""
 
-#: partials/poll-edit-form.php:435 polldaddy.php:4487
+#: partials/poll-edit-form.php:445
+#: polldaddy.php:4528
 msgid "Paper Medium"
 msgstr ""
 
-#: partials/poll-edit-form.php:436 polldaddy.php:4488
+#: partials/poll-edit-form.php:446
+#: polldaddy.php:4529
 msgid "Paper Wide"
 msgstr ""
 
-#: partials/poll-edit-form.php:437 polldaddy.php:4489
+#: partials/poll-edit-form.php:447
+#: polldaddy.php:4530
 msgid "Skull Dark Narrow"
 msgstr ""
 
-#: partials/poll-edit-form.php:438 polldaddy.php:4490
+#: partials/poll-edit-form.php:448
+#: polldaddy.php:4531
 msgid "Skull Dark Medium"
 msgstr ""
 
-#: partials/poll-edit-form.php:439 polldaddy.php:4491
+#: partials/poll-edit-form.php:449
+#: polldaddy.php:4532
 msgid "Skull Dark Wide"
 msgstr ""
 
-#: partials/poll-edit-form.php:440 polldaddy.php:4492
+#: partials/poll-edit-form.php:450
+#: polldaddy.php:4533
 msgid "Skull Light Narrow"
 msgstr ""
 
-#: partials/poll-edit-form.php:441 polldaddy.php:4493
+#: partials/poll-edit-form.php:451
+#: polldaddy.php:4534
 msgid "Skull Light Medium"
 msgstr ""
 
-#: partials/poll-edit-form.php:442 polldaddy.php:4494
+#: partials/poll-edit-form.php:452
+#: polldaddy.php:4535
 msgid "Skull Light Wide"
 msgstr ""
 
-#: partials/poll-edit-form.php:443 partials/poll-edit-form.php:751
-#: polldaddy.php:2375 polldaddy.php:4495
+#: partials/poll-edit-form.php:453
+#: partials/poll-edit-form.php:765
+#: polldaddy.php:2400
+#: polldaddy.php:4536
 msgid "Micro"
 msgstr ""
 
-#: partials/poll-edit-form.php:444 polldaddy.php:4496
+#: partials/poll-edit-form.php:454
+#: polldaddy.php:4537
 msgid "Plastic White Narrow"
 msgstr ""
 
-#: partials/poll-edit-form.php:445 polldaddy.php:4497
+#: partials/poll-edit-form.php:455
+#: polldaddy.php:4538
 msgid "Plastic White Medium"
 msgstr ""
 
-#: partials/poll-edit-form.php:446 polldaddy.php:4498
+#: partials/poll-edit-form.php:456
+#: polldaddy.php:4539
 msgid "Plastic White Wide"
 msgstr ""
 
-#: partials/poll-edit-form.php:447 polldaddy.php:4499
+#: partials/poll-edit-form.php:457
+#: polldaddy.php:4540
 msgid "Plastic Grey Narrow"
 msgstr ""
 
-#: partials/poll-edit-form.php:448 polldaddy.php:4500
+#: partials/poll-edit-form.php:458
+#: polldaddy.php:4541
 msgid "Plastic Grey Medium"
 msgstr ""
 
-#: partials/poll-edit-form.php:449 polldaddy.php:4501
+#: partials/poll-edit-form.php:459
+#: polldaddy.php:4542
 msgid "Plastic Grey Wide"
 msgstr ""
 
-#: partials/poll-edit-form.php:450 polldaddy.php:4502
+#: partials/poll-edit-form.php:460
+#: polldaddy.php:4543
 msgid "Plastic Black Narrow"
 msgstr ""
 
-#: partials/poll-edit-form.php:451 polldaddy.php:4503
+#: partials/poll-edit-form.php:461
+#: polldaddy.php:4544
 msgid "Plastic Black Medium"
 msgstr ""
 
-#: partials/poll-edit-form.php:452 polldaddy.php:4504
+#: partials/poll-edit-form.php:462
+#: polldaddy.php:4545
 msgid "Plastic Black Wide"
 msgstr ""
 
-#: partials/poll-edit-form.php:453 polldaddy.php:4505
+#: partials/poll-edit-form.php:463
+#: polldaddy.php:4546
 msgid "Manga Narrow"
 msgstr ""
 
-#: partials/poll-edit-form.php:454 polldaddy.php:4506
+#: partials/poll-edit-form.php:464
+#: polldaddy.php:4547
 msgid "Manga Medium"
 msgstr ""
 
-#: partials/poll-edit-form.php:455 polldaddy.php:4507
+#: partials/poll-edit-form.php:465
+#: polldaddy.php:4548
 msgid "Manga Wide"
 msgstr ""
 
-#: partials/poll-edit-form.php:456 polldaddy.php:4508
+#: partials/poll-edit-form.php:466
+#: polldaddy.php:4549
 msgid "Tech Dark Narrow"
 msgstr ""
 
-#: partials/poll-edit-form.php:457 polldaddy.php:4509
+#: partials/poll-edit-form.php:467
+#: polldaddy.php:4550
 msgid "Tech Dark Medium"
 msgstr ""
 
-#: partials/poll-edit-form.php:458 polldaddy.php:4510
+#: partials/poll-edit-form.php:468
+#: polldaddy.php:4551
 msgid "Tech Dark Wide"
 msgstr ""
 
-#: partials/poll-edit-form.php:459 polldaddy.php:4511
+#: partials/poll-edit-form.php:469
+#: polldaddy.php:4552
 msgid "Tech Grey Narrow"
 msgstr ""
 
-#: partials/poll-edit-form.php:460 polldaddy.php:4512
+#: partials/poll-edit-form.php:470
+#: polldaddy.php:4553
 msgid "Tech Grey Medium"
 msgstr ""
 
-#: partials/poll-edit-form.php:461 polldaddy.php:4513
+#: partials/poll-edit-form.php:471
+#: polldaddy.php:4554
 msgid "Tech Grey Wide"
 msgstr ""
 
-#: partials/poll-edit-form.php:462 polldaddy.php:4514
+#: partials/poll-edit-form.php:472
+#: polldaddy.php:4555
 msgid "Tech Light Narrow"
 msgstr ""
 
-#: partials/poll-edit-form.php:463 polldaddy.php:4515
+#: partials/poll-edit-form.php:473
+#: polldaddy.php:4556
 msgid "Tech Light Medium"
 msgstr ""
 
-#: partials/poll-edit-form.php:464 polldaddy.php:4516
+#: partials/poll-edit-form.php:474
+#: polldaddy.php:4557
 msgid "Tech Light Wide"
 msgstr ""
 
-#: partials/poll-edit-form.php:465 polldaddy.php:4517
+#: partials/poll-edit-form.php:475
+#: polldaddy.php:4558
 msgid "Working Male Narrow"
 msgstr ""
 
-#: partials/poll-edit-form.php:466 polldaddy.php:4518
+#: partials/poll-edit-form.php:476
+#: polldaddy.php:4559
 msgid "Working Male Medium"
 msgstr ""
 
-#: partials/poll-edit-form.php:467 polldaddy.php:4519
+#: partials/poll-edit-form.php:477
+#: polldaddy.php:4560
 msgid "Working Male Wide"
 msgstr ""
 
-#: partials/poll-edit-form.php:468 polldaddy.php:4520
+#: partials/poll-edit-form.php:478
+#: polldaddy.php:4561
 msgid "Working Female Narrow"
 msgstr ""
 
-#: partials/poll-edit-form.php:469 polldaddy.php:4521
+#: partials/poll-edit-form.php:479
+#: polldaddy.php:4562
 msgid "Working Female Medium"
 msgstr ""
 
-#: partials/poll-edit-form.php:470 polldaddy.php:4522
+#: partials/poll-edit-form.php:480
+#: polldaddy.php:4563
 msgid "Working Female Wide"
 msgstr ""
 
-#: partials/poll-edit-form.php:471 polldaddy.php:4523
+#: partials/poll-edit-form.php:481
+#: polldaddy.php:4564
 msgid "Thinking Male Narrow"
 msgstr ""
 
-#: partials/poll-edit-form.php:472 polldaddy.php:4524
+#: partials/poll-edit-form.php:482
+#: polldaddy.php:4565
 msgid "Thinking Male Medium"
 msgstr ""
 
-#: partials/poll-edit-form.php:473 polldaddy.php:4525
+#: partials/poll-edit-form.php:483
+#: polldaddy.php:4566
 msgid "Thinking Male Wide"
 msgstr ""
 
-#: partials/poll-edit-form.php:474 polldaddy.php:4526
+#: partials/poll-edit-form.php:484
+#: polldaddy.php:4567
 msgid "Thinking Female Narrow"
 msgstr ""
 
-#: partials/poll-edit-form.php:475 polldaddy.php:4527
+#: partials/poll-edit-form.php:485
+#: polldaddy.php:4568
 msgid "Thinking Female Medium"
 msgstr ""
 
-#: partials/poll-edit-form.php:476 polldaddy.php:4528
+#: partials/poll-edit-form.php:486
+#: polldaddy.php:4569
 msgid "Thinking Female Wide"
 msgstr ""
 
-#: partials/poll-edit-form.php:477 polldaddy.php:4529
+#: partials/poll-edit-form.php:487
+#: polldaddy.php:4570
 msgid "Sunset Narrow"
 msgstr ""
 
-#: partials/poll-edit-form.php:478 polldaddy.php:4530
+#: partials/poll-edit-form.php:488
+#: polldaddy.php:4571
 msgid "Sunset Medium"
 msgstr ""
 
-#: partials/poll-edit-form.php:479 polldaddy.php:4531
+#: partials/poll-edit-form.php:489
+#: polldaddy.php:4572
 msgid "Sunset Wide"
 msgstr ""
 
-#: partials/poll-edit-form.php:480 polldaddy.php:4532
+#: partials/poll-edit-form.php:490
+#: polldaddy.php:4573
 msgid "Music Medium"
 msgstr ""
 
-#: partials/poll-edit-form.php:481 polldaddy.php:4533
+#: partials/poll-edit-form.php:491
+#: polldaddy.php:4574
 msgid "Music Wide"
 msgstr ""
 
-#: partials/poll-edit-form.php:503
+#: partials/poll-edit-form.php:513
 msgid "Poll Style"
 msgstr ""
 
-#: partials/poll-edit-form.php:508
+#: partials/poll-edit-form.php:518
 msgid "Crowdsignal Styles"
 msgstr ""
 
-#: partials/poll-edit-form.php:510 partials/poll-edit-form.php:720
-#: partials/polls-table.php:297 polldaddy.php:1781 polldaddy.php:3244
-#: polldaddy.php:4030 polldaddy.php:4453
+#: partials/poll-edit-form.php:520
+#: partials/poll-edit-form.php:734
+#: partials/polls-table.php:297
+#: polldaddy.php:1800
+#: polldaddy.php:3271
+#: polldaddy.php:4067
+#: polldaddy.php:4494
 msgid "Custom Styles"
 msgstr ""
 
-#: partials/poll-edit-form.php:595
+#: partials/poll-edit-form.php:605
 msgid "Crowdsignal Style"
 msgstr ""
 
-#: partials/poll-edit-form.php:601
+#: partials/poll-edit-form.php:611
 msgid "Custom Style"
 msgstr ""
 
-#: partials/poll-edit-form.php:679
+#: partials/poll-edit-form.php:689
 msgid "Please choose a custom style…"
 msgstr ""
 
-#: partials/poll-edit-form.php:688
+#: partials/poll-edit-form.php:698
 msgid "Please choose a style."
 msgstr ""
 
-#: partials/poll-edit-form.php:692
+#: partials/poll-edit-form.php:702
 msgid "You currently have no custom styles created."
 msgstr ""
 
-#: partials/poll-edit-form.php:694
+#: partials/poll-edit-form.php:704
 msgid "New Style"
 msgstr ""
 
-#: partials/poll-edit-form.php:700
 #. translators: link to support site for custom poll styles
-msgid ""
-"Did you know we have a new editor for building your own custom poll styles? "
-"Find out more <a href=\"%s\" target=\"_blank\">here</a>."
+#: partials/poll-edit-form.php:710
+#, php-format
+msgid "Did you know we have a new editor for building your own custom poll styles? Find out more <a href=\"%s\" target=\"_blank\">here</a>."
 msgstr ""
 
-#: partials/poll-edit-form.php:710 partials/polls-table.php:291
-#: polldaddy.php:3239 polldaddy.php:4025 polldaddy.php:4448
-#. translators: name of the rating being deleted
+#. translators: %s is the name of the rating being deleted
+#: partials/poll-edit-form.php:722
+#: partials/polls-table.php:291
+#: polldaddy.php:3266
+#: polldaddy.php:4062
+#: polldaddy.php:4489
+#, php-format
 msgid "Are you sure you want to delete the rating for \"%s\"?"
 msgstr ""
 
-#: partials/poll-edit-form.php:711 polldaddy.php:3240 polldaddy.php:4026
-#: polldaddy.php:4449
+#. translators: %s is the name of the poll being deleted
+#: partials/poll-edit-form.php:725
+#: polldaddy.php:3267
+#: polldaddy.php:4063
+#: polldaddy.php:4490
+#, php-format
 msgid "Are you sure you want to delete \"%s\"?"
 msgstr ""
 
-#: partials/poll-edit-form.php:712 partials/polls-table.php:294
-#: polldaddy.php:3241 polldaddy.php:4027 polldaddy.php:4450
+#: partials/poll-edit-form.php:726
+#: partials/polls-table.php:294
+#: polldaddy.php:3268
+#: polldaddy.php:4064
+#: polldaddy.php:4491
 msgid "Are you sure you want to delete this answer?"
 msgstr ""
 
-#: partials/poll-edit-form.php:719 partials/polls-table.php:296
-#: polldaddy.php:3243 polldaddy.php:4029 polldaddy.php:4452
+#: partials/poll-edit-form.php:733
+#: partials/polls-table.php:296
+#: polldaddy.php:3270
+#: polldaddy.php:4066
+#: polldaddy.php:4493
 msgid "Standard Styles"
 msgstr ""
 
-#: partials/poll-edit-form.php:733 polldaddy.php:2369
+#: partials/poll-edit-form.php:747
+#: polldaddy.php:2394
 msgid "Aluminum"
 msgstr ""
 
-#: partials/poll-edit-form.php:736 polldaddy.php:2370
+#: partials/poll-edit-form.php:750
+#: polldaddy.php:2395
 msgid "Plain White"
 msgstr ""
 
-#: partials/poll-edit-form.php:739 polldaddy.php:2371
+#: partials/poll-edit-form.php:753
+#: polldaddy.php:2396
 msgid "Plain Black"
 msgstr ""
 
-#: partials/poll-edit-form.php:742 polldaddy.php:2372
+#: partials/poll-edit-form.php:756
+#: polldaddy.php:2397
 msgid "Paper"
 msgstr ""
 
-#: partials/poll-edit-form.php:745 polldaddy.php:2373
+#: partials/poll-edit-form.php:759
+#: polldaddy.php:2398
 msgid "Skull Dark"
 msgstr ""
 
-#: partials/poll-edit-form.php:748 polldaddy.php:2374
+#: partials/poll-edit-form.php:762
+#: polldaddy.php:2399
 msgid "Skull Light"
 msgstr ""
 
-#: partials/poll-edit-form.php:752 partials/poll-edit-form.php:802
+#: partials/poll-edit-form.php:766
+#: partials/poll-edit-form.php:816
 msgid "Width 150px, the micro style is useful when space is tight."
 msgstr ""
 
-#: partials/poll-edit-form.php:755
+#: partials/poll-edit-form.php:769
 msgid "Plastic White"
 msgstr ""
 
-#: partials/poll-edit-form.php:758
+#: partials/poll-edit-form.php:772
 msgid "Plastic Grey"
 msgstr ""
 
-#: partials/poll-edit-form.php:761
+#: partials/poll-edit-form.php:775
 msgid "Plastic Black"
 msgstr ""
 
-#: partials/poll-edit-form.php:764
+#: partials/poll-edit-form.php:778
 msgid "Manga"
 msgstr ""
 
-#: partials/poll-edit-form.php:767
+#: partials/poll-edit-form.php:781
 msgid "Tech Dark"
 msgstr ""
 
-#: partials/poll-edit-form.php:770
+#: partials/poll-edit-form.php:784
 msgid "Tech Grey"
 msgstr ""
 
-#: partials/poll-edit-form.php:773
+#: partials/poll-edit-form.php:787
 msgid "Tech Light"
 msgstr ""
 
-#: partials/poll-edit-form.php:776
+#: partials/poll-edit-form.php:790
 msgid "Working Male"
 msgstr ""
 
-#: partials/poll-edit-form.php:779
+#: partials/poll-edit-form.php:793
 msgid "Working Female"
 msgstr ""
 
-#: partials/poll-edit-form.php:782
+#: partials/poll-edit-form.php:796
 msgid "Thinking Male"
 msgstr ""
 
-#: partials/poll-edit-form.php:785
+#: partials/poll-edit-form.php:799
 msgid "Thinking Female"
 msgstr ""
 
-#: partials/poll-edit-form.php:788
+#: partials/poll-edit-form.php:802
 msgid "Sunset"
 msgstr ""
 
-#: partials/poll-edit-form.php:791
+#: partials/poll-edit-form.php:805
 msgid "Music"
 msgstr ""
 
-#: partials/poll-edit-form.php:796
+#: partials/poll-edit-form.php:810
 msgid "Wide"
 msgstr ""
 
-#: partials/poll-edit-form.php:797 polldaddy.php:3799
+#: partials/poll-edit-form.php:811
+#: polldaddy.php:3836
 msgid "Medium"
 msgstr ""
 
-#: partials/poll-edit-form.php:798
+#: partials/poll-edit-form.php:812
 msgid "Narrow"
 msgstr ""
 
-#: partials/poll-edit-form.php:799
+#: partials/poll-edit-form.php:813
 msgid "Width: 630px, the wide style is good for blog posts."
 msgstr ""
 
-#: partials/poll-edit-form.php:800
+#: partials/poll-edit-form.php:814
 msgid "Width: 300px, the medium style is good for general use."
 msgstr ""
 
-#: partials/poll-edit-form.php:801
+#: partials/poll-edit-form.php:815
 msgid "Width 150px, the narrow style is good for sidebars etc."
 msgstr ""
 
@@ -888,7 +1021,8 @@ msgstr ""
 msgid "Unknown"
 msgstr ""
 
-#: partials/polls-table.php:200 partials/polls-table.php:219
+#: partials/polls-table.php:200
+#: partials/polls-table.php:219
 msgid "Open"
 msgstr ""
 
@@ -900,26 +1034,34 @@ msgstr ""
 msgid "Results"
 msgstr ""
 
-#: partials/polls-table.php:216 partials/settings-2.php:78
-#: partials/settings-2.php:114 polldaddy.php:2251
+#: partials/polls-table.php:216
+#: partials/settings-2.php:78
+#: partials/settings-2.php:114
+#: polldaddy.php:2276
 msgid "Edit"
 msgstr ""
 
-#: partials/polls-table.php:219 polldaddy.php:3719
+#: partials/polls-table.php:219
+#: polldaddy.php:3754
 msgid "Close"
 msgstr ""
 
-#: partials/polls-table.php:223 polldaddy.php:2214 polldaddy.php:2256
-#: polldaddy.php:4314 polldaddy.php:4390
+#: partials/polls-table.php:223
+#: polldaddy.php:2239
+#: polldaddy.php:2281
+#: polldaddy.php:4353
+#: polldaddy.php:4431
 msgid "Delete"
 msgstr ""
 
-#: partials/polls-table.php:227 polldaddy.php:3634
+#: partials/polls-table.php:227
+#: polldaddy.php:3665
 msgid "Preview"
 msgstr ""
 
+#. translators: %s is the name of the poll being deleted
 #: partials/polls-table.php:293
-#. translators: name of the poll being deleted
+#, php-format
 msgid "Are you sure you want to delete the poll %s?"
 msgstr ""
 
@@ -943,7 +1085,8 @@ msgstr ""
 msgid "Help"
 msgstr ""
 
-#: partials/settings-2.php:10 polldaddy.php:3608
+#: partials/settings-2.php:10
+#: polldaddy.php:3639
 msgid "Advanced Settings"
 msgstr ""
 
@@ -952,16 +1095,11 @@ msgid "Multiuser Account"
 msgstr ""
 
 #: partials/settings-2.php:31
-msgid ""
-"You have granted authors, editors and admin users of this site access to "
-"your Crowdsignal account."
+msgid "You have granted authors, editors and admin users of this site access to your Crowdsignal account."
 msgstr ""
 
 #: partials/settings-2.php:32
-msgid ""
-"Warning: This is a deprecated feature and wont’t be supported in future. If "
-"you disable the Multi-User-Access feature, you won’t be able to activate it "
-"again."
+msgid "Warning: This is a deprecated feature and wont’t be supported in future. If you disable the Multi-User-Access feature, you won’t be able to activate it again."
 msgstr ""
 
 #: partials/settings-2.php:66
@@ -969,17 +1107,15 @@ msgid "Reset Connection Settings"
 msgstr ""
 
 #: partials/settings-2.php:68
-msgid ""
-"If you are experiencing problems connecting to the Crowdsignal website "
-"resetting your connection settings may help. A backup will be made. After "
-"resetting, link your account again with the same API key."
+msgid "If you are experiencing problems connecting to the Crowdsignal website resetting your connection settings may help. A backup will be made. After resetting, link your account again with the same API key."
 msgstr ""
 
 #: partials/settings-2.php:69
 msgid "The following settings will be reset:"
 msgstr ""
 
-#: partials/settings-2.php:90 partials/settings-2.php:126
+#: partials/settings-2.php:90
+#: partials/settings-2.php:126
 msgid "* The usercode is like a password, keep it secret."
 msgstr ""
 
@@ -996,9 +1132,7 @@ msgid "Restore Previous Settings"
 msgstr ""
 
 #: partials/settings-2.php:106
-msgid ""
-"The connection settings for this site were reset but a backup was made. The "
-"following settings can be restored:"
+msgid "The connection settings for this site were reset but a backup was made. The following settings can be restored:"
 msgstr ""
 
 #: partials/settings-2.php:132
@@ -1010,16 +1144,11 @@ msgid "Restore Ratings Settings"
 msgstr ""
 
 #: partials/settings-2.php:145
-msgid ""
-"Different rating settings detected. If you are missing ratings on your "
-"posts, pages or comments you can restore the original rating settings by "
-"clicking the button below."
+msgid "Different rating settings detected. If you are missing ratings on your posts, pages or comments you can restore the original rating settings by clicking the button below."
 msgstr ""
 
 #: partials/settings-2.php:146
-msgid ""
-"This tells the plugin to look for this data in a different rating in your "
-"Crowdsignal account."
+msgid "This tells the plugin to look for this data in a different rating in your Crowdsignal account."
 msgstr ""
 
 #: partials/settings-2.php:152
@@ -1034,15 +1163,15 @@ msgstr ""
 msgid "API Key"
 msgstr ""
 
-#: partials/settings.php:24
 #. translators: Placeholder is the text "Crowdsignal".
-msgid ""
-"Your website is connected to a %s account to collect responses and data "
-"from your visitors."
+#: partials/settings.php:24
+#, php-format
+msgid "Your website is connected to a %s account to collect responses and data from your visitors."
 msgstr ""
 
-#: partials/settings.php:32
 #. translators: Placeholder is the text "Crowdsignal acount page".
+#: partials/settings.php:32
+#, php-format
 msgid "Visit your %s to find out more about your settings."
 msgstr ""
 
@@ -1051,9 +1180,7 @@ msgid "Crowdsignal account page"
 msgstr ""
 
 #: partials/settings.php:42
-msgid ""
-"If you have a Crowdsignal account, click the \"Get API Key\" button to "
-"connect. This will open a new window."
+msgid "If you have a Crowdsignal account, click the \"Get API Key\" button to connect. This will open a new window."
 msgstr ""
 
 #: partials/settings.php:46
@@ -1076,7 +1203,9 @@ msgstr ""
 msgid "Connect"
 msgstr ""
 
-#: polldaddy-org.php:64 polldaddy.php:196 polldaddy.php:204
+#: polldaddy-org.php:64
+#: polldaddy.php:198
+#: polldaddy.php:206
 msgid "Ratings"
 msgstr ""
 
@@ -1084,11 +1213,13 @@ msgstr ""
 msgid "Dashboard"
 msgstr ""
 
-#: polldaddy-org.php:151 polldaddy.php:252
+#: polldaddy-org.php:151
+#: polldaddy.php:253
 msgid "Email address required"
 msgstr ""
 
-#: polldaddy-org.php:154 polldaddy.php:255
+#: polldaddy-org.php:154
+#: polldaddy.php:256
 msgid "Password required"
 msgstr ""
 
@@ -1105,18 +1236,15 @@ msgid "Login to Crowdsignal failed.  Double check your email address and passwor
 msgstr ""
 
 #: polldaddy-org.php:234
-msgid ""
-"If your email address and password are correct, your host may not support "
-"secure logins."
+msgid "If your email address and password are correct, your host may not support secure logins."
 msgstr ""
 
 #: polldaddy-org.php:235
-msgid ""
-"In that case, you may be able to log in to Crowdsignal by unchecking the "
-"\"Use SSL to Log in\" checkbox."
+msgid "In that case, you may be able to log in to Crowdsignal by unchecking the \"Use SSL to Log in\" checkbox."
 msgstr ""
 
-#: polldaddy-org.php:247 polldaddy.php:322
+#: polldaddy-org.php:247
+#: polldaddy.php:323
 msgid "Account could not be accessed.  Are your email address and password correct?"
 msgstr ""
 
@@ -1129,9 +1257,7 @@ msgid "Use SSL to Log in"
 msgstr ""
 
 #: polldaddy-org.php:295
-msgid ""
-"This ensures a secure login to your Crowdsignal account.  Only uncheck if "
-"you are having problems logging in."
+msgid "This ensures a secure login to your Crowdsignal account.  Only uncheck if you are having problems logging in."
 msgstr ""
 
 #: polldaddy-org.php:334
@@ -1139,9 +1265,7 @@ msgid "Load Shortcodes Inline"
 msgstr ""
 
 #: polldaddy-org.php:339
-msgid ""
-"This will load the Crowdsignal shortcodes inline rather than in the page "
-"footer."
+msgid "This will load the Crowdsignal shortcodes inline rather than in the page footer."
 msgstr ""
 
 #: polldaddy-org.php:348
@@ -1157,9 +1281,7 @@ msgid "Warning"
 msgstr ""
 
 #: polldaddy-org.php:358
-msgid ""
-"This is a deprecated feature and is not supported anymore. If you disable "
-"this Multi User Access you won't be able to activate it again."
+msgid "This is a deprecated feature and is not supported anymore. If you disable this Multi User Access you won't be able to activate it again."
 msgstr ""
 
 #: polldaddy-org.php:370
@@ -1186,7 +1308,8 @@ msgstr ""
 msgid "Top Rated"
 msgstr ""
 
-#: polldaddy-org.php:589 polldaddy.php:4370
+#: polldaddy-org.php:589
+#: polldaddy.php:4411
 msgid "Title"
 msgstr ""
 
@@ -1210,1029 +1333,1109 @@ msgstr ""
 msgid "How many items would you like to display?"
 msgstr ""
 
-#: polldaddy-org.php:655
-msgid ""
-"Crowdsignal features will be unavailable until you link your "
-"Crowdsignal.com account. Please visit the <a href=\"%s\">plugin settings "
-"page</a> to login."
+#. translators: %s is the URL to the plugin settings page
+#: polldaddy-org.php:657
+#, php-format
+msgid "Crowdsignal features will be unavailable until you link your Crowdsignal.com account. Please visit the <a href=\"%s\">plugin settings page</a> to login."
 msgstr ""
 
 #: polldaddy-shortcode.php:279
 msgid "Take Our Survey!"
 msgstr ""
 
-#: polldaddy.php:186 polldaddy.php:187
+#: polldaddy.php:188
+#: polldaddy.php:189
 msgid "Feedback"
 msgstr ""
 
-#: polldaddy.php:206
-#. translators: %s placeholder is the setting page type (Poll or Rating).
-msgid "%s"
-msgstr ""
-
-#: polldaddy.php:285
+#: polldaddy.php:286
 msgid "Can't connect to Polldaddy.com"
 msgstr ""
 
-#: polldaddy.php:312
+#: polldaddy.php:313
 msgid "Invalid Account"
 msgstr ""
 
-#: polldaddy.php:504
+#: polldaddy.php:505
 msgid "Crowdsignal blocks in WordPress"
 msgstr ""
 
-#: polldaddy.php:839
+#: polldaddy.php:840
 msgid "Star Colors"
 msgstr ""
 
-#: polldaddy.php:839 polldaddy.php:3796
+#: polldaddy.php:840
+#: polldaddy.php:3833
 msgid "Star Size"
 msgstr ""
 
-#: polldaddy.php:840
+#: polldaddy.php:841
 msgid "Nero Type"
 msgstr ""
 
-#: polldaddy.php:840
+#: polldaddy.php:841
 msgid "Nero Size"
 msgstr ""
 
-#: polldaddy.php:902
+#: polldaddy.php:903
 msgid "You have just reset your Polldaddy connection settings."
 msgstr ""
 
-#: polldaddy.php:985
+#: polldaddy.php:986
 msgid "You are not allowed to delete this poll."
 msgstr ""
 
-#: polldaddy.php:993 polldaddy.php:1029 polldaddy.php:1065 polldaddy.php:1098
+#: polldaddy.php:994
+#: polldaddy.php:1030
+#: polldaddy.php:1066
+#: polldaddy.php:1099
 msgid "Invalid Poll Author"
 msgstr ""
 
-#: polldaddy.php:1021
+#: polldaddy.php:1022
 msgid "You are not allowed to open this poll."
 msgstr ""
 
-#: polldaddy.php:1057
+#: polldaddy.php:1058
 msgid "You are not allowed to close this poll."
 msgstr ""
 
-#: polldaddy.php:1090 polldaddy.php:2023
+#: polldaddy.php:1091
+#: polldaddy.php:2047
 msgid "You are not allowed to edit this poll."
 msgstr ""
 
-#: polldaddy.php:1105
+#: polldaddy.php:1106
 msgid "Poll not found"
 msgstr ""
 
-#: polldaddy.php:1147
+#: polldaddy.php:1148
 msgid "Invalid answers"
 msgstr ""
 
-#: polldaddy.php:1188 polldaddy.php:1294
+#: polldaddy.php:1189
+#: polldaddy.php:1295
 msgid "You must include at least 2 answers"
 msgstr ""
 
-#: polldaddy.php:1199 polldaddy.php:1329
+#: polldaddy.php:1200
+#: polldaddy.php:1330
 msgid "Please choose a poll style"
 msgstr ""
 
-#: polldaddy.php:1229
+#: polldaddy.php:1230
 msgid "Poll could not be updated"
 msgstr ""
 
-#: polldaddy.php:1354
+#: polldaddy.php:1355
 msgid "Poll could not be created"
 msgstr ""
 
-#: polldaddy.php:1409
+#: polldaddy.php:1410
 msgid "Style could not be updated"
 msgstr ""
 
-#: polldaddy.php:1439
+#: polldaddy.php:1440
 msgid "Style could not be created"
 msgstr ""
 
-#: polldaddy.php:1567
+#: polldaddy.php:1568
 msgid "Account could not be accessed.  Is your API code correct?"
 msgstr ""
 
-#: polldaddy.php:1573
+#: polldaddy.php:1574
 msgid "Account could not be imported. Did you enter the correct API key?"
 msgstr ""
 
-#: polldaddy.php:1593
+#: polldaddy.php:1594
 msgid "Poll deleted."
 msgstr ""
 
-#: polldaddy.php:1595
+#. translators: %s is the number of polls deleted
+#: polldaddy.php:1598
+#, php-format
 msgid "%s Poll Deleted."
 msgid_plural "%s Polls Deleted."
 msgstr[0] ""
 msgstr[1] ""
 
-#: polldaddy.php:1601
+#: polldaddy.php:1604
 msgid "Poll opened."
 msgstr ""
 
-#: polldaddy.php:1603
+#. translators: %s is the number of polls opened
+#: polldaddy.php:1608
+#, php-format
 msgid "%s Poll Opened."
 msgid_plural "%s Polls Opened."
 msgstr[0] ""
 msgstr[1] ""
 
-#: polldaddy.php:1609
+#: polldaddy.php:1614
 msgid "Poll closed."
 msgstr ""
 
-#: polldaddy.php:1611
+#. translators: %s is the number of polls closed
+#: polldaddy.php:1618
+#, php-format
 msgid "%s Poll Closed."
 msgid_plural "%s Polls Closed."
 msgstr[0] ""
 msgstr[1] ""
 
-#: polldaddy.php:1615
+#: polldaddy.php:1622
 msgid "Poll updated."
 msgstr ""
 
-#: polldaddy.php:1618
+#: polldaddy.php:1625
 msgid "Poll created."
 msgstr ""
 
-#: polldaddy.php:1624
+#: polldaddy.php:1631
 msgid "Custom Style updated."
 msgstr ""
 
-#: polldaddy.php:1627
+#: polldaddy.php:1634
 msgid "Custom Style created."
 msgstr ""
 
-#: polldaddy.php:1632
+#: polldaddy.php:1639
 msgid "Custom Style deleted."
 msgstr ""
 
-#: polldaddy.php:1634
+#. translators: %s is the number of styles deleted
+#: polldaddy.php:1643
+#, php-format
 msgid "%s Style Deleted."
 msgid_plural "%s Custom Styles Deleted."
 msgstr[0] ""
 msgstr[1] ""
 
-#: polldaddy.php:1639
+#: polldaddy.php:1648
 msgid "Account Linked."
 msgstr ""
 
-#: polldaddy.php:1642
+#: polldaddy.php:1651
 msgid "There was a problem linking your account."
 msgstr ""
 
-#: polldaddy.php:1645
+#: polldaddy.php:1654
 msgid "Options Updated."
 msgstr ""
 
-#: polldaddy.php:1650
+#: polldaddy.php:1659
 msgid "Rating deleted."
 msgstr ""
 
-#: polldaddy.php:1652
+#. translators: %s is the number of ratings deleted
+#: polldaddy.php:1663
+#, php-format
 msgid "%s Rating Deleted."
 msgid_plural "%s Ratings Deleted."
 msgstr[0] ""
 msgstr[1] ""
 
-#: polldaddy.php:1663
+#: polldaddy.php:1674
 msgid "Error: An error has occurred;  Poll not created."
 msgstr ""
 
-#: polldaddy.php:1666
+#: polldaddy.php:1677
 msgid "Error: An error has occurred;  Poll not updated."
 msgstr ""
 
-#: polldaddy.php:1670
-msgid ""
-"Error: An error has occurred;  Account could not be imported.  Perhaps your "
-"email address or password is incorrect?"
+#: polldaddy.php:1681
+msgid "Error: An error has occurred;  Account could not be imported.  Perhaps your email address or password is incorrect?"
 msgstr ""
 
-#: polldaddy.php:1672
+#: polldaddy.php:1683
 msgid "Error: An error has occurred;  Account could not be created."
 msgstr ""
 
-#: polldaddy.php:1735
+#. translators: %s is the URL to all polls
+#: polldaddy.php:1748
+#, php-format
 msgid "Preview Poll <a href=\"%s\" class=\"add-new-h2\">All Polls</a>"
 msgstr ""
 
-#: polldaddy.php:1747
-msgid ""
-"Poll Results <a href=\"%s\" class=\"add-new-h2\">All Polls</a> <a "
-"href=\"%s\" class=\"add-new-h2\">Edit Poll</a>"
+#. translators: %s is the URL to all polls, %s is the URL to edit poll
+#: polldaddy.php:1762
+#, php-format
+msgid "Poll Results <a href=\"%1$s\" class=\"add-new-h2\">All Polls</a> <a href=\"%2$s\" class=\"add-new-h2\">Edit Poll</a>"
 msgstr ""
 
-#: polldaddy.php:1758
-msgid ""
-"Edit Poll <a href=\"%s\" class=\"add-new-h2\">All Polls</a> <a href=\"%s\" "
-"class=\"add-new-h2\">View Results</a>"
+#. translators: %s is the URL to all polls, %s is the URL to view results
+#: polldaddy.php:1774
+#, php-format
+msgid "Edit Poll <a href=\"%1$s\" class=\"add-new-h2\">All Polls</a> <a href=\"%2$s\" class=\"add-new-h2\">View Results</a>"
 msgstr ""
 
-#: polldaddy.php:1770
+#. translators: %s is the URL to all polls
+#: polldaddy.php:1788
+#, php-format
 msgid "Add New Poll <a href=\"%s\" class=\"add-new-h2\">All Polls</a>"
 msgstr ""
 
-#: polldaddy.php:1779
+#. translators: %s is the URL to add new style
+#: polldaddy.php:1798
+#, php-format
 msgid "Custom Styles <a href=\"%s\" class=\"add-new-h2\">Add New</a>"
 msgstr ""
 
-#: polldaddy.php:1790
+#. translators: %s is the URL to list styles
+#: polldaddy.php:1812
+#, php-format
 msgid "Edit Style <a href=\"%s\" class=\"add-new-h2\">List Styles</a>"
 msgstr ""
 
-#: polldaddy.php:1799
+#. translators: %s is the URL to list styles
+#: polldaddy.php:1823
+#, php-format
 msgid "Create Style <a href=\"%s\" class=\"add-new-h2\">List Styles</a>"
 msgstr ""
 
-#: polldaddy.php:1955
+#: polldaddy.php:1979
 msgid "Disconnected user"
 msgstr ""
 
-#: polldaddy.php:2112
+#: polldaddy.php:2136
 msgid "Answer"
 msgstr ""
 
-#: polldaddy.php:2113 polldaddy.php:2162 polldaddy.php:3653 polldaddy.php:4373
+#: polldaddy.php:2137
+#: polldaddy.php:2187
+#: polldaddy.php:3684
+#: polldaddy.php:4414
 msgid "Votes"
 msgstr ""
 
-#: polldaddy.php:2114
+#: polldaddy.php:2138
 msgid "Percent"
 msgstr ""
 
-#: polldaddy.php:2129
+#. translators: %s is the URL to other answers results
+#: polldaddy.php:2154
+#, php-format
 msgid "Other (<a href=\"%s\">see below</a>)"
 msgstr ""
 
-#: polldaddy.php:2161
+#: polldaddy.php:2186
 msgid "Other Answer"
 msgstr ""
 
-#: polldaddy.php:2213 polldaddy.php:4313
+#: polldaddy.php:2238
+#: polldaddy.php:4352
 msgid "Actions"
 msgstr ""
 
-#: polldaddy.php:2216 polldaddy.php:4317
+#: polldaddy.php:2241
+#: polldaddy.php:4356
 msgid "Apply"
 msgstr ""
 
-#: polldaddy.php:2226 polldaddy.php:2642
+#: polldaddy.php:2251
+#: polldaddy.php:2667
 msgid "Style"
 msgstr ""
 
-#: polldaddy.php:2227
+#: polldaddy.php:2252
 msgid "Last Modified"
 msgstr ""
 
-#: polldaddy.php:2259 polldaddy.php:4398
+#: polldaddy.php:2284
+#: polldaddy.php:4439
 msgid "Y/m/d g:i:s A"
 msgstr ""
 
-#: polldaddy.php:2259
+#: polldaddy.php:2284
 msgid "Y/m/d"
 msgstr ""
 
-#: polldaddy.php:2271
+#: polldaddy.php:2296
 msgid "You haven't used our fancy style editor to create any custom styles!"
 msgstr ""
 
-#: polldaddy.php:2272
+#: polldaddy.php:2297
 msgid "Why don't you go ahead and get started on that?"
 msgstr ""
 
-#: polldaddy.php:2273
+#: polldaddy.php:2298
 msgid "Create a Custom Style Now"
 msgstr ""
 
-#: polldaddy.php:2351
+#: polldaddy.php:2376
 msgid "Style Name"
 msgstr ""
 
-#: polldaddy.php:2363
+#: polldaddy.php:2388
 msgid "Preload Basic Style"
 msgstr ""
 
-#: polldaddy.php:2377
+#: polldaddy.php:2402
 msgid "Load Style"
 msgstr ""
 
-#: polldaddy.php:2383
+#: polldaddy.php:2408
 msgid "Text Direction"
 msgstr ""
 
-#: polldaddy.php:2387
+#: polldaddy.php:2412
 msgid "Force RTL"
 msgstr ""
 
-#: polldaddy.php:2388
+#: polldaddy.php:2413
 msgid "Force LTR"
 msgstr ""
 
-#: polldaddy.php:2394
+#: polldaddy.php:2419
 msgid "Style Editor"
 msgstr ""
 
-#: polldaddy.php:2398
+#: polldaddy.php:2423
 msgid "Select a template part to edit:"
 msgstr ""
 
-#: polldaddy.php:2401
+#: polldaddy.php:2426
 msgid "Poll Box"
 msgstr ""
 
-#: polldaddy.php:2402
+#: polldaddy.php:2427
 msgid "Question"
 msgstr ""
 
-#: polldaddy.php:2403
+#: polldaddy.php:2428
 msgid "Answer Group"
 msgstr ""
 
-#: polldaddy.php:2404
+#: polldaddy.php:2429
 msgid "Answer Check"
 msgstr ""
 
-#: polldaddy.php:2406
+#: polldaddy.php:2431
 msgid "Other Input"
 msgstr ""
 
-#: polldaddy.php:2407
+#: polldaddy.php:2432
 msgid "Vote Button"
 msgstr ""
 
-#: polldaddy.php:2408
+#: polldaddy.php:2433
 msgid "Links"
 msgstr ""
 
-#: polldaddy.php:2409
+#: polldaddy.php:2434
 msgid "Feedback Group"
 msgstr ""
 
-#: polldaddy.php:2410
+#: polldaddy.php:2435
 msgid "Results Group"
 msgstr ""
 
-#: polldaddy.php:2411
+#: polldaddy.php:2436
 msgid "Results Percent"
 msgstr ""
 
-#: polldaddy.php:2412
+#: polldaddy.php:2437
 msgid "Results Votes"
 msgstr ""
 
-#: polldaddy.php:2413
+#: polldaddy.php:2438
 msgid "Results Text"
 msgstr ""
 
-#: polldaddy.php:2414
+#: polldaddy.php:2439
 msgid "Results Background"
 msgstr ""
 
-#: polldaddy.php:2415
+#: polldaddy.php:2440
 msgid "Results Bar"
 msgstr ""
 
-#: polldaddy.php:2416 polldaddy.php:3198
+#: polldaddy.php:2441
+#: polldaddy.php:3225
 msgid "Total Votes"
 msgstr ""
 
-#: polldaddy.php:2432 polldaddy.php:3872
+#: polldaddy.php:2457
+#: polldaddy.php:3909
 msgid "Font"
 msgstr ""
 
-#: polldaddy.php:2435
+#: polldaddy.php:2460
 msgid "Background"
 msgstr ""
 
-#: polldaddy.php:2438
+#: polldaddy.php:2463
 msgid "Border"
 msgstr ""
 
-#: polldaddy.php:2441
+#: polldaddy.php:2466
 msgid "Margin"
 msgstr ""
 
-#: polldaddy.php:2444
+#: polldaddy.php:2469
 msgid "Padding"
 msgstr ""
 
-#: polldaddy.php:2447 polldaddy.php:2604 polldaddy.php:3018
+#: polldaddy.php:2472
+#: polldaddy.php:2629
+#: polldaddy.php:3043
 msgid "Width"
 msgstr ""
 
-#: polldaddy.php:2450 polldaddy.php:3034
+#: polldaddy.php:2475
+#: polldaddy.php:3059
 msgid "Height"
 msgstr ""
 
-#: polldaddy.php:2453 polldaddy.php:3043 polldaddy.php:3858
+#: polldaddy.php:2478
+#: polldaddy.php:3068
+#: polldaddy.php:3895
 msgid "Position"
 msgstr ""
 
-#: polldaddy.php:2466 polldaddy.php:2488
+#: polldaddy.php:2491
+#: polldaddy.php:2513
 msgid "Font Size"
 msgstr ""
 
-#: polldaddy.php:2503 polldaddy.php:2562 polldaddy.php:2659 polldaddy.php:3886
+#: polldaddy.php:2528
+#: polldaddy.php:2587
+#: polldaddy.php:2684
+#: polldaddy.php:3923
 msgid "Color"
 msgstr ""
 
-#: polldaddy.php:2509 polldaddy.php:3919
+#: polldaddy.php:2534
+#: polldaddy.php:3956
 msgid "Bold"
 msgstr ""
 
-#: polldaddy.php:2515 polldaddy.php:3928
+#: polldaddy.php:2540
+#: polldaddy.php:3965
 msgid "Italic"
 msgstr ""
 
-#: polldaddy.php:2521
+#: polldaddy.php:2546
 msgid "Underline"
 msgstr ""
 
-#: polldaddy.php:2527 polldaddy.php:3905
+#: polldaddy.php:2552
+#: polldaddy.php:3942
 msgid "Line Height"
 msgstr ""
 
-#: polldaddy.php:2549 polldaddy.php:3844
+#: polldaddy.php:2574
+#: polldaddy.php:3881
 msgid "Align"
 msgstr ""
 
-#: polldaddy.php:2552 polldaddy.php:2822 polldaddy.php:2977 polldaddy.php:3847
+#: polldaddy.php:2577
+#: polldaddy.php:2847
+#: polldaddy.php:3002
+#: polldaddy.php:3884
 msgid "Left"
 msgstr ""
 
-#: polldaddy.php:2553 polldaddy.php:3847
+#: polldaddy.php:2578
+#: polldaddy.php:3884
 msgid "Center"
 msgstr ""
 
-#: polldaddy.php:2554 polldaddy.php:2746 polldaddy.php:2901 polldaddy.php:3847
-#: polldaddy.php:3861
+#: polldaddy.php:2579
+#: polldaddy.php:2771
+#: polldaddy.php:2926
+#: polldaddy.php:3884
+#: polldaddy.php:3898
 msgid "Right"
 msgstr ""
 
-#: polldaddy.php:2568 popups.php:62
+#: polldaddy.php:2593
+#: popups.php:77
 msgid "Image URL"
 msgstr ""
 
-#: polldaddy.php:2568 polldaddy.php:3018
+#: polldaddy.php:2593
+#: polldaddy.php:3043
 msgid "Click here for more information"
 msgstr ""
 
-#: polldaddy.php:2574
+#: polldaddy.php:2599
 msgid "Image Repeat"
 msgstr ""
 
-#: polldaddy.php:2577
+#: polldaddy.php:2602
 msgid "repeat"
 msgstr ""
 
-#: polldaddy.php:2578
+#: polldaddy.php:2603
 msgid "no-repeat"
 msgstr ""
 
-#: polldaddy.php:2579
+#: polldaddy.php:2604
 msgid "repeat-x"
 msgstr ""
 
-#: polldaddy.php:2580
+#: polldaddy.php:2605
 msgid "repeat-y"
 msgstr ""
 
-#: polldaddy.php:2585
+#: polldaddy.php:2610
 msgid "Image Position"
 msgstr ""
 
-#: polldaddy.php:2588
+#: polldaddy.php:2613
 msgid "left top"
 msgstr ""
 
-#: polldaddy.php:2589
+#: polldaddy.php:2614
 msgid "left center"
 msgstr ""
 
-#: polldaddy.php:2590
+#: polldaddy.php:2615
 msgid "left bottom"
 msgstr ""
 
-#: polldaddy.php:2591
+#: polldaddy.php:2616
 msgid "center top"
 msgstr ""
 
-#: polldaddy.php:2592
+#: polldaddy.php:2617
 msgid "center center"
 msgstr ""
 
-#: polldaddy.php:2593
+#: polldaddy.php:2618
 msgid "center bottom"
 msgstr ""
 
-#: polldaddy.php:2594
+#: polldaddy.php:2619
 msgid "right top"
 msgstr ""
 
-#: polldaddy.php:2595
+#: polldaddy.php:2620
 msgid "right center"
 msgstr ""
 
-#: polldaddy.php:2596
+#: polldaddy.php:2621
 msgid "right bottom"
 msgstr ""
 
-#: polldaddy.php:2645
+#: polldaddy.php:2670
 msgid "none"
 msgstr ""
 
-#: polldaddy.php:2646
+#: polldaddy.php:2671
 msgid "solid"
 msgstr ""
 
-#: polldaddy.php:2647
+#: polldaddy.php:2672
 msgid "dotted"
 msgstr ""
 
-#: polldaddy.php:2648
+#: polldaddy.php:2673
 msgid "dashed"
 msgstr ""
 
-#: polldaddy.php:2649
+#: polldaddy.php:2674
 msgid "double"
 msgstr ""
 
-#: polldaddy.php:2650
+#: polldaddy.php:2675
 msgid "groove"
 msgstr ""
 
-#: polldaddy.php:2651
+#: polldaddy.php:2676
 msgid "inset"
 msgstr ""
 
-#: polldaddy.php:2652
+#: polldaddy.php:2677
 msgid "outset"
 msgstr ""
 
-#: polldaddy.php:2653
+#: polldaddy.php:2678
 msgid "ridge"
 msgstr ""
 
-#: polldaddy.php:2654
+#: polldaddy.php:2679
 msgid "hidden"
 msgstr ""
 
-#: polldaddy.php:2665
+#: polldaddy.php:2690
 msgid "Rounded Corners"
 msgstr ""
 
-#: polldaddy.php:2701
+#: polldaddy.php:2726
 msgid "Not supported in Internet Explorer."
 msgstr ""
 
-#: polldaddy.php:2708 polldaddy.php:2863 polldaddy.php:3861
+#: polldaddy.php:2733
+#: polldaddy.php:2888
+#: polldaddy.php:3898
 msgid "Top"
 msgstr ""
 
-#: polldaddy.php:2784 polldaddy.php:2939 polldaddy.php:3861
+#: polldaddy.php:2809
+#: polldaddy.php:2964
+#: polldaddy.php:3898
 msgid "Bottom"
 msgstr ""
 
-#: polldaddy.php:3026
-msgid ""
-"If you change the width of the<br/> poll you may also need to change<br/> "
-"the width of your answers."
+#: polldaddy.php:3051
+msgid "If you change the width of the<br/> poll you may also need to change<br/> the width of your answers."
 msgstr ""
 
-#: polldaddy.php:3075 polldaddy.php:3249
+#: polldaddy.php:3100
+#: polldaddy.php:3276
 msgid "Do you mostly use the internet at work, in school or at home?"
 msgstr ""
 
-#: polldaddy.php:3088
+#: polldaddy.php:3113
 msgid "I use it in school."
 msgstr ""
 
-#: polldaddy.php:3096 polldaddy.php:3154
+#: polldaddy.php:3121
+#: polldaddy.php:3181
 msgid "I use it at home."
 msgstr ""
 
-#: polldaddy.php:3104 polldaddy.php:3168
+#: polldaddy.php:3129
+#: polldaddy.php:3195
 msgid "I use it every where I go, at work and home and anywhere else that I can!"
 msgstr ""
 
-#: polldaddy.php:3112 polldaddy.php:3182
+#: polldaddy.php:3137
+#: polldaddy.php:3209
 msgid "Other"
 msgstr ""
 
-#: polldaddy.php:3124 polldaddy.php:3647
+#: polldaddy.php:3149
+#: polldaddy.php:3678
 msgid "Vote"
 msgstr ""
 
-#: polldaddy.php:3126
+#: polldaddy.php:3151
 msgid "View Results"
 msgstr ""
 
-#: polldaddy.php:3140
+#: polldaddy.php:3165
 msgid "I use it in school!"
 msgstr ""
 
-#: polldaddy.php:3142 polldaddy.php:3156 polldaddy.php:3170 polldaddy.php:3184
+#. translators: %d is the number of votes
+#: polldaddy.php:3169
+#: polldaddy.php:3183
+#: polldaddy.php:3197
+#: polldaddy.php:3211
+#, php-format
 msgid "(%d votes)"
 msgstr ""
 
-#: polldaddy.php:3206
+#: polldaddy.php:3233
 msgid "Return To Poll"
 msgstr ""
 
-#: polldaddy.php:3227
+#: polldaddy.php:3254
 msgid "Save Style"
 msgstr ""
 
-#: polldaddy.php:3229
+#: polldaddy.php:3256
 msgid "Check this box if you wish to update the polls that use this style."
 msgstr ""
 
-#: polldaddy.php:3248
+#: polldaddy.php:3275
 msgid "Thank you for voting!"
 msgstr ""
 
-#: polldaddy.php:3348
+#: polldaddy.php:3375
 msgid "Could not connect to the Crowdsignal API"
 msgstr ""
 
-#: polldaddy.php:3351
+#: polldaddy.php:3378
 msgid "The API URL is incorrect"
 msgstr ""
 
-#: polldaddy.php:3354
+#: polldaddy.php:3381
 msgid "Your API request did not return any data"
 msgstr ""
 
-#: polldaddy.php:3360
+#: polldaddy.php:3387
 msgid "There was an error creating your rating widget"
 msgstr ""
 
-#: polldaddy.php:3471
+#: polldaddy.php:3498
 msgid "Rating Settings"
 msgstr ""
 
-#: polldaddy.php:3474
+#: polldaddy.php:3501
 msgid "Rating updated"
 msgstr ""
 
-#: polldaddy.php:3486 polldaddy.php:3507 polldaddy.php:4321
+#: polldaddy.php:3513
+#: polldaddy.php:3534
+#: polldaddy.php:4360
 msgid "Posts"
 msgstr ""
 
-#: polldaddy.php:3490 polldaddy.php:3543 polldaddy.php:4321
+#: polldaddy.php:3517
+#: polldaddy.php:3570
+#: polldaddy.php:4360
 msgid "Pages"
 msgstr ""
 
-#: polldaddy.php:3504 polldaddy.php:3541 polldaddy.php:3563
+#: polldaddy.php:3531
+#: polldaddy.php:3568
+#: polldaddy.php:3590
 msgid "Show Ratings on"
 msgstr ""
 
-#: polldaddy.php:3506
+#: polldaddy.php:3533
 msgid "Front Page, Archive Pages, and Search Results"
 msgstr ""
 
-#: polldaddy.php:3511
+#: polldaddy.php:3538
 msgid "Position Front Page, Archive Pages, and Search Results Ratings"
 msgstr ""
 
-#: polldaddy.php:3514 polldaddy.php:3528
+#: polldaddy.php:3541
+#: polldaddy.php:3555
 msgid "Above each blog post"
 msgstr ""
 
-#: polldaddy.php:3514 polldaddy.php:3528
+#: polldaddy.php:3541
+#: polldaddy.php:3555
 msgid "Below each blog post"
 msgstr ""
 
-#: polldaddy.php:3525
+#: polldaddy.php:3552
 msgid "Position Post Ratings"
 msgstr ""
 
-#: polldaddy.php:3547
+#: polldaddy.php:3574
 msgid "Position Page Ratings"
 msgstr ""
 
-#: polldaddy.php:3550
+#: polldaddy.php:3577
 msgid "Above each blog page"
 msgstr ""
 
-#: polldaddy.php:3550
+#: polldaddy.php:3577
 msgid "Below each blog page"
 msgstr ""
 
-#: polldaddy.php:3569
+#: polldaddy.php:3596
 msgid "Position Comment Ratings"
 msgstr ""
 
-#: polldaddy.php:3572
+#: polldaddy.php:3599
 msgid "Above each comment"
 msgstr ""
 
-#: polldaddy.php:3572
+#: polldaddy.php:3599
 msgid "Below each comment"
 msgstr ""
 
-#: polldaddy.php:3584 polldaddy.php:3624
+#: polldaddy.php:3611
+#: polldaddy.php:3655
 msgid "Save Changes"
 msgstr ""
 
-#: polldaddy.php:3593
-msgid ""
-"Previous settings for ratings on this site discovered. You can restore them "
-"on the <a href='%s'>poll settings page</a> if your site is missing ratings "
-"after resetting your connection settings."
+#. translators: %s is the URL to Crowdsignal settings page
+#: polldaddy.php:3622
+#, php-format
+msgid "Previous settings for ratings on this site discovered. You can restore them on the <a href='%s'>poll settings page</a> if your site is missing ratings after resetting your connection settings."
 msgstr ""
 
-#: polldaddy.php:3619
+#: polldaddy.php:3650
 msgid "Save Advanced Settings"
 msgstr ""
 
-#: polldaddy.php:3636
+#: polldaddy.php:3667
 msgid "This is a demo of what your rating widget will look like"
 msgstr ""
 
-#: polldaddy.php:3643
+#: polldaddy.php:3674
 msgid "Customize Labels"
 msgstr ""
 
-#: polldaddy.php:3659
+#: polldaddy.php:3690
 msgid "Rate This"
 msgstr ""
 
-#: polldaddy.php:3665
+#. translators: %d is the number of stars
+#: polldaddy.php:3698
+#, php-format
 msgid "%d star"
 msgstr ""
 
-#: polldaddy.php:3671 polldaddy.php:3677 polldaddy.php:3683 polldaddy.php:3689
+#. translators: %d is the number of stars
+#: polldaddy.php:3706
+#: polldaddy.php:3712
+#: polldaddy.php:3718
+#: polldaddy.php:3724
+#, php-format
 msgid "%d stars"
 msgstr ""
 
-#: polldaddy.php:3695
+#: polldaddy.php:3730
 msgid "Thank You"
 msgstr ""
 
-#: polldaddy.php:3701
+#: polldaddy.php:3736
 msgid "Rate Up"
 msgstr ""
 
-#: polldaddy.php:3707
+#: polldaddy.php:3742
 msgid "Rate Down"
 msgstr ""
 
-#: polldaddy.php:3713
+#: polldaddy.php:3748
 msgid "Most Popular Content"
 msgstr ""
 
-#: polldaddy.php:3725
+#: polldaddy.php:3760
 msgid "All"
 msgstr ""
 
-#: polldaddy.php:3731
+#: polldaddy.php:3766
 msgid "Today"
 msgstr ""
 
-#: polldaddy.php:3737
+#: polldaddy.php:3772
 msgid "This Week"
 msgstr ""
 
-#: polldaddy.php:3743
+#: polldaddy.php:3778
 msgid "This Month"
 msgstr ""
 
-#: polldaddy.php:3749
+#: polldaddy.php:3784
 msgid "Rated"
 msgstr ""
 
-#: polldaddy.php:3755
+#: polldaddy.php:3790
 msgid "There are no rated items for this period"
 msgstr ""
 
-#: polldaddy.php:3766
+#: polldaddy.php:3801
 msgid "Rating Type"
 msgstr ""
 
-#: polldaddy.php:3768
-msgid ""
-"Here you can choose how you want your rating to display. The 5 star rating "
-"is the most commonly used. The Nero rating is useful for keeping it simple."
+#: polldaddy.php:3803
+msgid "Here you can choose how you want your rating to display. The 5 star rating is the most commonly used. The Nero rating is useful for keeping it simple."
 msgstr ""
 
-#: polldaddy.php:3776
+#. translators: %d is the number of stars
+#: polldaddy.php:3813
+#, php-format
 msgid "%d Star Rating"
 msgstr ""
 
-#: polldaddy.php:3785
+#: polldaddy.php:3822
 msgid "Nero Rating"
 msgstr ""
 
-#: polldaddy.php:3792
+#: polldaddy.php:3829
 msgid "Rating Style"
 msgstr ""
 
-#: polldaddy.php:3799
+#: polldaddy.php:3836
 msgid "Small"
 msgstr ""
 
-#: polldaddy.php:3799
+#: polldaddy.php:3836
 msgid "Large"
 msgstr ""
 
-#: polldaddy.php:3810
+#: polldaddy.php:3847
 msgid "Star Color"
 msgstr ""
 
-#: polldaddy.php:3813
+#: polldaddy.php:3850
 msgid "Yellow"
 msgstr ""
 
-#: polldaddy.php:3813
+#: polldaddy.php:3850
 msgid "Red"
 msgstr ""
 
-#: polldaddy.php:3813
+#: polldaddy.php:3850
 msgid "Blue"
 msgstr ""
 
-#: polldaddy.php:3813
+#: polldaddy.php:3850
 msgid "Green"
 msgstr ""
 
-#: polldaddy.php:3813
+#: polldaddy.php:3850
 msgid "Grey"
 msgstr ""
 
-#: polldaddy.php:3822
+#: polldaddy.php:3859
 msgid "Hand"
 msgstr ""
 
-#: polldaddy.php:3833
+#: polldaddy.php:3870
 msgid "Custom Image"
 msgstr ""
 
-#: polldaddy.php:3840
+#: polldaddy.php:3877
 msgid "Text Layout & Font"
 msgstr ""
 
-#: polldaddy.php:3875 polldaddy.php:3894 polldaddy.php:3908
+#: polldaddy.php:3912
+#: polldaddy.php:3931
+#: polldaddy.php:3945
 msgid "Inherit"
 msgstr ""
 
-#: polldaddy.php:3891
+#: polldaddy.php:3928
 msgid "Size"
 msgstr ""
 
-#: polldaddy.php:3940
+#: polldaddy.php:3977
 msgid "Extra Settings"
 msgstr ""
 
-#: polldaddy.php:3944
+#: polldaddy.php:3981
 msgid "Results Popup"
 msgstr ""
 
-#: polldaddy.php:3950
+#: polldaddy.php:3987
 msgid "Uncheck this box to disable the results popup"
 msgstr ""
 
-#: polldaddy.php:3957 polldaddy.php:3981 polldaddy.php:4004
+#: polldaddy.php:3994
+#: polldaddy.php:4018
+#: polldaddy.php:4041
 msgid "Rating ID"
 msgstr ""
 
-#: polldaddy.php:3963
+#: polldaddy.php:4000
 msgid "This is the rating ID used in posts"
 msgstr ""
 
-#: polldaddy.php:3968
+#: polldaddy.php:4005
 msgid "Exclude Posts"
 msgstr ""
 
-#: polldaddy.php:3974
-msgid ""
-"Enter the Post IDs where you want to exclude ratings from. Please use a "
-"comma-delimited list, eg. 1,2,3"
+#: polldaddy.php:4011
+msgid "Enter the Post IDs where you want to exclude ratings from. Please use a comma-delimited list, eg. 1,2,3"
 msgstr ""
 
-#: polldaddy.php:3987
+#: polldaddy.php:4024
 msgid "This is the rating ID used in pages"
 msgstr ""
 
-#: polldaddy.php:3992
+#: polldaddy.php:4029
 msgid "Exclude Pages"
 msgstr ""
 
-#: polldaddy.php:3998
-msgid ""
-"Enter the Page IDs where you want to exclude ratings from. Please use a "
-"comma-delimited list, eg. 1,2,3"
+#: polldaddy.php:4035
+msgid "Enter the Page IDs where you want to exclude ratings from. Please use a comma-delimited list, eg. 1,2,3"
 msgstr ""
 
-#: polldaddy.php:4010
+#: polldaddy.php:4047
 msgid "This is the rating ID used in comments"
 msgstr ""
 
-#: polldaddy.php:4293
+#: polldaddy.php:4330
 msgid "&laquo;"
 msgstr ""
 
-#: polldaddy.php:4294
+#: polldaddy.php:4331
 msgid "&raquo;"
 msgstr ""
 
-#: polldaddy.php:4303
+#. translators: %s is the URL to Crowdsignal settings page
+#: polldaddy.php:4342
+#, php-format
 msgid "Rating Results <a href=\"%s\" class=\"add-new-h2\">Settings</a>"
 msgstr ""
 
-#: polldaddy.php:4305
+#: polldaddy.php:4344
 msgid "Rating Results"
 msgstr ""
 
-#: polldaddy.php:4330
+#: polldaddy.php:4369
 msgid "Last 24 hours"
 msgstr ""
 
-#: polldaddy.php:4330
+#: polldaddy.php:4369
 msgid "Last 7 days"
 msgstr ""
 
-#: polldaddy.php:4330
+#: polldaddy.php:4369
 msgid "Last 31 days"
 msgstr ""
 
-#: polldaddy.php:4330
+#: polldaddy.php:4369
 msgid "Last 3 months"
 msgstr ""
 
-#: polldaddy.php:4330
+#: polldaddy.php:4369
 msgid "Last 12 months"
 msgstr ""
 
-#: polldaddy.php:4330
+#: polldaddy.php:4369
 msgid "All time"
 msgstr ""
 
-#: polldaddy.php:4338
+#: polldaddy.php:4377
 msgid "Filter"
 msgstr ""
 
-#: polldaddy.php:4340
+#: polldaddy.php:4379
 msgid "* The results are cached and are updated every hour"
 msgstr ""
 
-#: polldaddy.php:4342
+#: polldaddy.php:4381
 msgid "* The results are cached and are updated every day"
 msgstr ""
 
-#: polldaddy.php:4344
+#: polldaddy.php:4383
 msgid "* The results are cached and are updated every 3 days"
 msgstr ""
 
-#: polldaddy.php:4358
+#. translators: %s is the report type
+#: polldaddy.php:4399
+#, php-format
 msgid "No ratings have been collected for your %s yet."
 msgstr ""
 
-#: polldaddy.php:4371
+#: polldaddy.php:4412
 msgid "Unique ID"
 msgstr ""
 
-#: polldaddy.php:4372
+#: polldaddy.php:4413
 msgid "Start Date"
 msgstr ""
 
-#: polldaddy.php:4374
+#: polldaddy.php:4415
 msgid "Average Rating"
 msgstr ""
 
-#: polldaddy.php:4623
+#: polldaddy.php:4664
 msgid "There are a few things you can do:"
 msgstr ""
 
-#: polldaddy.php:4624
-msgid ""
-"Press reload on your browser and reload this page. There may have been a "
-"temporary problem communicating with Crowdsignal.com"
+#: polldaddy.php:4665
+msgid "Press reload on your browser and reload this page. There may have been a temporary problem communicating with Crowdsignal.com"
 msgstr ""
 
-#: polldaddy.php:4625
-msgid ""
-"Go to the <a href='%s'>poll settings page</a>, scroll to the end of the "
-"page and reset your connection settings. Link your account again with the "
-"same API key."
+#. translators: %1$s is the URL to Crowdsignal settings page
+#: polldaddy.php:4667
+#, php-format
+msgid "Go to the <a href='%s'>poll settings page</a>, scroll to the end of the page and reset your connection settings. Link your account again with the same API key."
 msgstr ""
 
-#: polldaddy.php:4626
-msgid ""
-"Contact <a href=\"%1$s\" %2$s>Crowdsignal support</a> and tell them your "
-"rating usercode is %3$s"
+#. translators: %1$s is the URL to Crowdsignal support, %2$s is the target attribute, %3$s is the rating usercode
+#: polldaddy.php:4669
+#, php-format
+msgid "Contact <a href=\"%1$s\" %2$s>Crowdsignal support</a> and tell them your rating usercode is %3$s"
 msgstr ""
 
-#: polldaddy.php:4626
-msgid ""
-"Also include the following information when contacting support to help us "
-"resolve your problem as quickly as possible:"
+#. translators: %1$s is the URL to Crowdsignal support, %2$s is the target attribute, %3$s is the rating usercode
+#: polldaddy.php:4669
+msgid "Also include the following information when contacting support to help us resolve your problem as quickly as possible:"
 msgstr ""
 
 #: popups.php:11
@@ -2243,46 +2446,38 @@ msgstr ""
 msgid "Paste your YouTube or Google Video URL above, or use the examples below."
 msgstr ""
 
-#: popups.php:20
-msgid "<a href=\"%s\" target=\"_blank\">YouTube instructions</a> %s"
-msgstr ""
-
-#: popups.php:21
-msgid "<a href=\"%s\" target=\"_blank\">Google instructions</a> %s"
-msgstr ""
-
+#. translators: %1$s is the URL to YouTube instructions, %2$s is the example shortcode
 #: popups.php:22
-msgid "<a href=\"%s\" target=\"_blank\">DailyMotion instructions</a> %s"
+#, php-format
+msgid "<a href=\"%1$s\" target=\"_blank\">YouTube instructions</a> %2$s"
 msgstr ""
 
-#: popups.php:29 popups.php:49 popups.php:78
+#. translators: %1$s is the URL to Google Video instructions, %2$s is the example shortcode
+#: popups.php:28
+#, php-format
+msgid "<a href=\"%1$s\" target=\"_blank\">Google instructions</a> %2$s"
+msgstr ""
+
+#. translators: %1$s is the URL to DailyMotion instructions, %2$s is the example shortcode
+#: popups.php:34
+#, php-format
+msgid "<a href=\"%1$s\" target=\"_blank\">DailyMotion instructions</a> %2$s"
+msgstr ""
+
+#: popups.php:44
+#: popups.php:64
+#: popups.php:93
 msgid "Insert into Poll"
 msgstr ""
 
-#: popups.php:41
+#: popups.php:56
 msgid "Audio File URL"
 msgstr ""
 
-#: popups.php:58
+#: popups.php:73
 msgid "Insert an image from another web site"
 msgstr ""
 
-#: popups.php:70
+#: popups.php:85
 msgid "Image Title"
-msgstr ""
-
-#. Plugin Name of the plugin/theme
-msgid "Crowdsignal Polls & Ratings"
-msgstr ""
-
-#. Plugin URI of the plugin/theme
-msgid "http://wordpress.org/extend/plugins/polldaddy/"
-msgstr ""
-
-#. Description of the plugin/theme
-msgid "Create and manage Crowdsignal polls and ratings in WordPress"
-msgstr ""
-
-#. Author of the plugin/theme
-msgid "Automattic, Inc."
 msgstr ""

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "main": "Gruntfile.js",
   "scripts": {
     "build": "grunt build",
-    "build:i18n": "grunt pot",
+    "build:i18n": "wp i18n make-pot . locale/polldaddy.pot",
     "package": "grunt package",
     "deploy": "grunt deploy"
   },

--- a/polldaddy.php
+++ b/polldaddy.php
@@ -1,11 +1,13 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 /**
  * Plugin Name: Crowdsignal Polls & Ratings
- * Plugin URI: http://wordpress.org/extend/plugins/polldaddy/
+ * Plugin URI: https://wordpress.org/plugins/polldaddy/
  * Description: Create and manage Crowdsignal polls and ratings in WordPress
  * Author: Automattic, Inc.
  * Author URL: https://crowdsignal.com/
  * Version: 3.1.2
+ * Text Domain: polldaddy
+ * Domain Path: /locale
  */
 
 // To hardcode your Polldaddy PartnerGUID (API Key), add the (uncommented) line below with the PartnerGUID to your `wp-config.php`


### PR DESCRIPTION
Fixes #123

## Changes proposed in this Pull Request
- Removed the `makepot` task from Gruntfile.js as it is no longer needed.
- Updated the `build:i18n` script in package.json to use WP-CLI for generating translation files.
- Added text domain and domain path in polldaddy.php for better localization support.
- Updated the locale/polldaddy.pot file with new headers and translation strings.


## Testing instructions

Running `npm run build:i18n` continues to create/update the `locale/polldaddy.pot` file, while showing up results of an audit for best practice checks to improve the localisation experience, and a slightly improved format (like separate lines for each reference, different file headers, etc.).

The WP-CLI command could also be used directly. The advantage of having it aliased by an NPM script is that it becomes a little more visible for those not familiar with WP-CLI, and where the POT file should live, etc.

## Screenshot or video

<img width="823" height="156" alt="Screenshot 2025-09-24 at 11 50 09" src="https://github.com/user-attachments/assets/19e35920-84d0-4404-b0a8-3ebc90d9aba1" />



<!-- Add the following only if this is meant to be in changelog -->
## Proposed changelog entry for your changes

refactor: Remove makepot task and update build script for i18n