### PR TITLE
Revert PR #112: Restore static.polldaddy.com domain

### DIFF
--- a/js/polldaddy-shortcode.js
+++ b/js/polldaddy-shortcode.js
@@ -13,7 +13,7 @@
 					if ( poll ) {
 						var poll_url = document.createElement("a");
 						poll_url.href = poll['url'];
-						if ( poll_url.hostname != 'secure.polldaddy.com' ) {
+						if ( poll_url.hostname != 'secure.polldaddy.com' && poll_url.hostname != 'static.polldaddy.com' ) {
 							return false;
 						}
 						var pathname = poll_url.pathname;

--- a/polldaddy-shortcode.php
+++ b/polldaddy-shortcode.php
@@ -180,7 +180,7 @@ CONTAINER;
 
 			$poll      = intval( $poll );
 			$poll_url  = sprintf( 'https://poll.fm/%d', $poll );
-			$poll_js   = sprintf( 'https://secure.polldaddy.com/p/%d.js', $poll );
+			$poll_js   = sprintf( '%s.polldaddy.com/p/%d.js', '//static', $poll );
 			$poll_link = sprintf( '<a href="%s">Take Our Poll</a>', $poll_url );
 
 			if ( $no_script ) {
@@ -442,16 +442,15 @@ new PolldaddyShortcode();
 
 if ( !function_exists( 'polldaddy_link' ) ) {
 	// http://polldaddy.com/poll/1562975/?view=results&msg=voted
-	// http://poll.fm/1562975
 	function polldaddy_link( $content ) {
-		if ( false === strpos( $content, "polldaddy.com/" ) && false === strpos( $content, "poll.fm/" ) )
+		if ( false === strpos( $content, "polldaddy.com/" ) )
 			return $content;
 		$textarr = wp_html_split( $content );
 		unset( $content );
 		foreach( $textarr as &$element ) {
 			if ( '' === $element || '<' === $element[0] )
 				continue;
-			$element = preg_replace( '!(?:\n|\A)https?://(polldaddy\.com/poll|poll\.fm)/([0-9]+?)(/.*)?(?:\n|\Z)!i', "\n<script type='text/javascript' charset='utf-8' src='//secure.polldaddy.com/p/$2.js'></script><noscript> <a href='https://poll.fm/$2'>View Poll</a></noscript>\n", $element );
+			$element = preg_replace( '!(?:\n|\A)https?://(polldaddy\.com/poll|poll\.fm)/([0-9]+?)(/.*)?(?:\n|\Z)!i', "\n<script type='text/javascript' charset='utf-8' src='//static.polldaddy.com/p/$2.js'></script><noscript> <a href='https://poll.fm/$2'>View Poll</a></noscript>\n", $element );
 		}
 		return join( $textarr );
 	}


### PR DESCRIPTION
## Summary
This PR reverts #112 which changed static.polldaddy.com to secure.polldaddy.com due to a 404 issue.

## Reason for Revert
- The static.polldaddy.com domain has been fixed and is now operational
- Testing confirms both domains serve identical content (HTTP 200)
- static.polldaddy.com is the preferred domain for poll resources

## Verification
- ✅ `curl https://static.polldaddy.com/p/1.js` returns HTTP 200
- ✅ Content matches secure.polldaddy.com exactly
- ✅ JavaScript validation updated to accept both domains for backwards compatibility

## Changes
- Restores `static.polldaddy.com` references in polldaddy-shortcode.php (lines 183, 453)
- Restores `static.polldaddy.com` validation in js/polldaddy-shortcode.js (line 16)
- Reverts poll.fm URL detection changes in polldaddy_link()