### PR TITLE
Deploying: We use main, not master now. Check for the right one

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -145,7 +145,7 @@ module.exports = function( grunt ){
 
     grunt.registerTask( 'build', [ 'gitinfo', 'clean', 'copy' ] );
 
-    grunt.registerTask( 'deploy', [ 'checkbranch:master', 'build', 'wp_deploy' ] );
+    grunt.registerTask( 'deploy', [ 'checkbranch:main', 'build', 'wp_deploy' ] );
     grunt.registerTask( 'deploy-unsafe', [ 'build', 'wp_deploy' ] );
 
     grunt.registerTask( 'package', [ 'build', 'zip' ] );


### PR DESCRIPTION
When deploying the plugin, there is a branch check. This used to check for "master" but we use "main" now so this check had to be updated.
