### PR TITLE
Release 3.1.6

### DIFF
--- a/polldaddy.php
+++ b/polldaddy.php
@@ -5,7 +5,7 @@
  * Description: Create and manage Crowdsignal polls and ratings in WordPress
  * Author: Automattic, Inc.
  * Author URL: https://crowdsignal.com/
- * Version: 3.1.5
+ * Version: 3.1.6
  * Text Domain: polldaddy
  * Domain Path: /languages
  * License:     GPL-2.0+

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: donncha, ice9js, cgastrell, digitalwaveride, jcheringer
 Tags: polls, vote, polling, surveys, rating
 Requires at least: 5.5
 Requires PHP: 5.6
-Tested up to: 6.9
-Stable tag: 3.1.5
+Tested up to: 7.0
+Stable tag: 3.1.6
 License: GPL-2.0+
 License URI: https://www.gnu.org/licenses/gpl-2.0.txt
 
@@ -100,6 +100,10 @@ Make sure to whitelist `api.crowdsignal.com` in your firewall to fix this.
 Bugfix and security release
 
 == Changelog ==
+
+= 3.1.6 =
+* Security: Verify attachment access in the image upload handler #154
+* fix: Avoid PHP notices from the rating shortcode on archive/taxonomy pages #104
 
 = 3.1.5 =
 * fix: Improve output escaping in style editor #147


### PR DESCRIPTION
Version bump for the 3.1.6 release.

- `Version` / `Stable tag` → 3.1.6
- `Tested up to` → 7.0
- Changelog entry

### Included since 3.1.5
- #154 — verify attachment access in the image upload handler
- #104 — avoid PHP notices from the rating shortcode on archive/taxonomy pages

After merge, run `make deploy` from `develop` to publish to WordPress.org SVN.