### PR TITLE
Fix readme.txt short description format

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -8,7 +8,6 @@ Stable tag: 3.1.6
 License: GPL-2.0+
 License URI: https://www.gnu.org/licenses/gpl-2.0.txt
 
-== Short Description ==
 Manage your Crowdsignal polls, surveys, quizzes, and ratings directly from the WordPress dashboard.
 
 == Description ==


### PR DESCRIPTION
WordPress.org reported on import:

> The Short Description section is missing. An excerpt was generated from your main plugin description.

The short description text was wrapped in a `== Short Description ==` heading. WordPress.org's readme format has no such section — the short description must be a plain, free-standing line between the header block and the first `==` section (see the canonical sample: https://wordpress.org/plugins/readme.txt). The heading caused the parser to treat it as an ordinary section, find no short-description line, and fall back to an auto-generated excerpt.

This removes the heading, leaving the existing one-line description (99 chars, under the 150 limit) in the correct position. No content change.

The live warning is cleared separately by committing the corrected `readme.txt` to SVN trunk.