### PR TITLE
Harden rating shortcode settings handling

### DIFF
--- a/js/polldaddy-shortcode.js
+++ b/js/polldaddy-shortcode.js
@@ -31,18 +31,31 @@
 			};
 
 			if ( ratings ){
-				var script = '';
-
 				$.each( ratings, function() {
 					var rating = $( this ).data( 'settings' );
 
-					if ( rating ) {
-						script += "PDRTJS_settings_" + rating['id'] + rating['item_id'] + "=" + rating['settings'] + "; if ( typeof PDRTJS_RATING !== 'undefined' ){ if ( typeof PDRTJS_" + rating['id'] + rating['item_id'] + "=='undefined' ){PDRTJS_" + rating['id'] + rating['item_id'] + "= new PDRTJS_RATING( PDRTJS_settings_" + rating['id'] + rating['item_id'] + " );}}";
+					if ( ! rating ) {
+						return;
+					}
+
+					// The 'settings' value is a JSON-encoded settings object built
+					// server-side (see polldaddy-shortcode.php). Parse it as data and
+					// assign it directly rather than concatenating it into a <script>,
+					// so the markup can only ever contribute data, never executable code.
+					var settings;
+					try {
+						settings = JSON.parse( rating['settings'] );
+					} catch ( e ) {
+						return;
+					}
+
+					var key = '' + rating['id'] + rating['item_id'];
+					window[ 'PDRTJS_settings_' + key ] = settings;
+
+					if ( typeof PDRTJS_RATING !== 'undefined' && typeof window[ 'PDRTJS_' + key ] === 'undefined' ) {
+						window[ 'PDRTJS_' + key ] = new PDRTJS_RATING( window[ 'PDRTJS_settings_' + key ] );
 					}
 				});
-
-				if ( script.length > 0 )
-					$( '#polldaddyRatings' ).after( "<script type='text/javascript' charset='utf-8' id='polldaddyDynamicRatings'>" + script +  "</script>" );
 			};
 		}
 	}


### PR DESCRIPTION
## Summary

Hardens how the rating shortcode renders its `data-settings` payload.

Previously the rating branch in `js/polldaddy-shortcode.js` concatenated the
`settings` value from the `data-settings` attribute into the body of a
dynamically injected `<script>` element.

This change parses the `settings` value as JSON data and assigns it directly to
the `PDRTJS_settings_*` global, then constructs the rating via `PDRTJS_RATING`
as before. The `data-settings` attribute can now only ever contribute data.

## Notes

- `settings` is JSON-encoded server-side (see `polldaddy-shortcode.php`), so
  parsing it as JSON matches the producer.
- Invalid/unparseable values are skipped rather than executed.
- Behaviour for valid ratings is unchanged: the same globals are defined and the
  same `PDRTJS_RATING` objects are created.
- `js/polldaddy-shortcode.js` is enqueued directly (no build/minify step), so no
  asset rebuild is required.
