### PR TITLE
Add agent skills configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# AGENTS.md
+
+Guidance for AI agents working in this repository.
+
+## Agent skills
+
+### Issue tracker
+
+Issues live in this repo's GitHub Issues (via the `gh` CLI). External pull requests are a triage surface — `/triage` pulls them into the same queue as issues. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Five canonical triage roles map to `status:`-prefixed labels (`status: needs-triage`, `status: needs-info`, `status: ready-for-agent`, `status: ready-for-human`, `status: wontfix`). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context: one `CONTEXT.md` + `docs/adr/` at the repo root (neither created yet). See `docs/agents/domain.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# CLAUDE.md
+
+@AGENTS.md

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,38 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+This repo is **single-context**: one `CONTEXT.md` + `docs/adr/` at the repo root.
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-example-decision.md
+│   └── 0002-another-decision.md
+└── ...
+```
+
+(A multi-context repo would instead have a `CONTEXT-MAP.md` at the root pointing to per-context `CONTEXT.md` files under `src/<context>/`, with context-scoped `src/<context>/docs/adr/`. That is not the layout here.)
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,32 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: yes.** External PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,19 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+This repo uses a `type:` / `status:` label prefix convention, so the state roles are `status:`-prefixed to match. `wontfix` reuses the pre-existing `status: wontfix` label; the other four were created to fit the convention.
+
+| Canonical role    | Label in our tracker      | Meaning                                  |
+| ----------------- | ------------------------- | ---------------------------------------- |
+| `needs-triage`    | `status: needs-triage`    | Maintainer needs to evaluate this issue  |
+| `needs-info`      | `status: needs-info`      | Waiting on reporter for more information |
+| `ready-for-agent` | `status: ready-for-agent` | Fully specified, ready for an AFK agent  |
+| `ready-for-human` | `status: ready-for-human` | Requires human implementation            |
+| `wontfix`         | `status: wontfix`         | Will not be actioned                     |
+
+Category roles map to the existing `type:` labels: `bug` → `type: bug`, `enhancement` → `type: enhancement`.
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
Scaffolds the per-repo configuration that the engineering skills (`triage`, `to-issues`, `to-prd`, `qa`, `diagnosing-bugs`, `tdd`, etc.) expect to read from. Generated via the `setup-matt-pocock-skills` skill.

## What's added

- **`AGENTS.md`** — holds the `## Agent skills` block summarising the three config areas.
- **`CLAUDE.md`** — imports `AGENTS.md` via `@AGENTS.md` so Claude Code picks it up.
- **`docs/agents/issue-tracker.md`** — issues live in GitHub Issues (via `gh`); external PRs are a triage surface, so `/triage` pulls them into the same queue as issues.
- **`docs/agents/triage-labels.md`** — maps the five canonical triage roles to this repo's `status:`-prefixed labels.
- **`docs/agents/domain.md`** — single-context layout (`CONTEXT.md` + `docs/adr/` at root) and the rules skills use to read domain docs.

## Also done outside this diff

Four triage state labels were created on the repo to match the mapping (reusing the existing `status: wontfix`):

- `status: needs-triage`
- `status: needs-info`
- `status: ready-for-agent`
- `status: ready-for-human`

## Notes

- No domain content is fabricated — `CONTEXT.md` / `docs/adr/` don't exist yet and are created lazily by domain-modeling skills as decisions land.
- This is the `crowdsignal-plugin` repo's own root config, separate from the `dev/cs/` monorepo `CLAUDE.md`.