### PR TITLE
Fix missing padding in the poll editor

### DIFF
--- a/css/polldaddy.css
+++ b/css/polldaddy.css
@@ -177,6 +177,15 @@ table.cs-dashboard__grid tr:hover .is-links a {
 	margin-left: -20px;
 }
 
+#manage-polls.cs-poll-editor {
+	margin-left: 0;
+	margin-right: 20px;
+}
+
+#manage-polls.cs-poll-editor #minor-publishing {
+	padding: 10px;
+}
+
 @media screen and (max-width: 782px) {
 	#manage-polls {
 		clear: none;

--- a/partials/poll-edit-form.php
+++ b/partials/poll-edit-form.php
@@ -39,7 +39,7 @@ $delete_media_link = '<a href="#" class="delete-media delete hidden" title="' . 
 				<div id="submitdiv" class="postbox">
 					<h2 class="postbox-title"><?php _e( 'Save', 'polldaddy' ); ?></h2>
 					<div class="inside">
-					<div class="minor-publishing">
+					<div id="minor-publishing">
 						<ul id="answer-options">
 
 							<?php

--- a/polldaddy.php
+++ b/polldaddy.php
@@ -1746,13 +1746,18 @@ class WP_Polldaddy {
 
 	function management_page() {
 		global $page, $action, $poll, $style, $rating;
-		$poll   = (int) $poll;
-		$style  = (int) $style;
-		$rating = esc_html( $rating );
-		$wrap_style = $page === 'polls' ? 'polls' : 'ratings';
+		$poll       = (int) $poll;
+		$style      = (int) $style;
+		$rating     = esc_html( $rating );
+		$wrap_style = 'polls' === $page ? 'polls' : 'ratings';
+		$wrap_class = "cs-dashboard__crowdsignal_{$wrap_style}_wrap";
+
+		if ( 'polls' === $page && in_array( $action, array( 'edit', 'edit-poll', 'create-poll' ), true ) ) {
+			$wrap_class .= ' cs-poll-editor';
+		}
 		?>
 
-		<div class="wrap cs-dashboard__crowdsignal_<?php echo $wrap_style ; ?>_wrap" id="manage-polls">
+		<div class="wrap <?php echo esc_attr( $wrap_class ); ?>" id="manage-polls">
 			<div class="cs-wrapper">
 				<?php
 				if ( 'polls' === $page ) {


### PR DESCRIPTION
Fixes #119

## Changes proposed in this Pull Request

The legacy poll editor inherited the full-bleed margins used by the Crowdsignal dashboard, causing the form to touch both edges of wp-admin. The Save panel also used a class instead of the standard `minor-publishing` ID, so its controls had no inner spacing.

This change:

- applies normal wp-admin gutters only to create and edit poll screens
- restores 10px padding to the Save panel
- leaves the full-bleed layout unchanged for other Crowdsignal pages

## Testing instructions

1. Connect a Crowdsignal account and open Crowdsignal > Polls.
2. Create or edit a poll.
3. Confirm the editor has normal left and right gutters.
4. Confirm the Save options have inner padding.
5. Confirm non-editor Crowdsignal screens retain their existing full-bleed layout.

Validated locally on WordPress 7.0.1:

- PHP syntax checks pass for both changed PHP files.
- Unit suite passes (2 tests, 2 assertions).
- `git diff --check` passes.
- Edit, create, preview, and narrow viewport layouts were visually checked.
- The integration suite could not start because offline wp-env did not populate `/wordpress-phpunit`; bootstrap failed before tests ran.
- Repository-wide PHPCS reports existing legacy violations; a filtered report found no violations on the new lines.

## Screenshot or video

Before: <img width="3020" height="1634" alt="image" src="https://github.com/user-attachments/assets/5c3cd5cc-24f7-4837-901f-c73a1d779cb6" />

After: <img width="1265" height="712" alt="image" src="https://github.com/user-attachments/assets/83c34c02-f1c8-49e4-b8e2-d0f6ef06b09c" />


## Proposed changelog entry for your changes

Fix missing padding in the Crowdsignal poll editor.

### Release Notes

* Fix missing padding in the Crowdsignal poll editor.
