### PR TITLE
polldaddy-client: use https for the API and drop the dead fsockopen path

### DIFF
--- a/polldaddy-client.php
+++ b/polldaddy-client.php
@@ -3,7 +3,7 @@
 require_once dirname( __FILE__ ) . '/polldaddy-xml.php';
 
 class api_client {
-	var $polldaddy_url = 'http://api.polldaddy.com/';
+	var $polldaddy_url = 'https://api.polldaddy.com/';
 	var $partnerGUID;
 	var $userCode;
 	var $admin        = 0;

--- a/polldaddy-client.php
+++ b/polldaddy-client.php
@@ -27,65 +27,22 @@ class api_client {
 
 		$this->requests[] = $this->request_xml;
 
-		if ( function_exists( 'wp_remote_post' ) ) {
-			$response = wp_remote_post( $this->polldaddy_url, array(
-				'headers' => array( 'Content-Type' => 'text/xml; charset=utf-8', 'Content-Length' => strlen( $this->request_xml ) ),
-				'user-agent' => 'Polldaddy PHP Client/0.1',
-				'timeout' => $timeout,
-				'body' => $this->request_xml
-			) );
-			if ( !$response || is_wp_error( $response ) ) {
-				$this->errors[-1] = "Can't connect";
-				return false;
-			}
-			$this->response_xml = wp_remote_retrieve_body( $response );
-		} else {
-			$parsed = parse_url( $this->polldaddy_url );
-
-			if ( !isset( $parsed['host'] ) && !isset( $parsed['scheme'] ) ) {
-				$this->errors[-1] = 'Invalid API URL';
-				return false;
-			}
-
-			$fp = fsockopen(
-				$parsed['host'],
-				$parsed['scheme'] == 'ssl' || $parsed['scheme'] == 'https' && extension_loaded('openssl') ? 443 : 80,
-				$err_num,
-				$err_str,
-				$timeout
-			);
-
-			if ( !$fp ) {
-				$this->errors[-1] = "Can't connect";
-				return false;
-			}
-
-			if ( function_exists( 'stream_set_timeout' ) )
-				stream_set_timeout( $fp, $timeout );
-
-			if ( !isset( $parsed['path']) || !$path = $parsed['path'] . ( isset($parsed['query']) ? '?' . $parsed['query'] : '' ) )
-				$path = '/';
-
-			$request  = "POST $path HTTP/1.0\r\n";
-			$request .= "Host: {$parsed['host']}\r\n";
-			$request .= "User-agent: Polldaddy PHP Client/0.1\r\n";
-			$request .= "Content-Type: text/xml; charset=utf-8\r\n";
-			$request .= 'Content-Length: ' . strlen( $this->request_xml ) . "\r\n";
-
-			fwrite( $fp, "$request\r\n$this->request_xml" );
-
-			$response = '';
-			while ( !feof( $fp ) )
-				$response .= fread( $fp, 4096 );
-			fclose( $fp );
-
-
-			if ( !$response ) {
-				$this->errors[-2] = 'No Data';
-			}
-
-			list($headers, $this->response_xml) = explode( "\r\n\r\n", $response, 2 );
+		if ( ! function_exists( 'wp_remote_post' ) ) {
+			$this->errors[-1] = "Can't connect";
+			return false;
 		}
+
+		$response = wp_remote_post( $this->polldaddy_url, array(
+			'headers' => array( 'Content-Type' => 'text/xml; charset=utf-8', 'Content-Length' => strlen( $this->request_xml ) ),
+			'user-agent' => 'Polldaddy PHP Client/0.1',
+			'timeout' => $timeout,
+			'body' => $this->request_xml
+		) );
+		if ( !$response || is_wp_error( $response ) ) {
+			$this->errors[-1] = "Can't connect";
+			return false;
+		}
+		$this->response_xml = wp_remote_retrieve_body( $response );
 
 		$this->responses[] = $this->response_xml;
 

--- a/tests/Unit/ApiClientTransportTest.php
+++ b/tests/Unit/ApiClientTransportTest.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Regression guard for the Crowdsignal API client transport scheme.
+ *
+ * The api_client base URL was set to https in Feb 2018 (issue #5) but was
+ * reinstated as http:// when the dormant client came back in the Aug 2021
+ * "Release v3" commit. This test pins the scheme to https so the API transport
+ * cannot silently regress again.
+ *
+ * @package Automattic\Crowdsignal\Tests\Unit
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\Crowdsignal\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Transport regression tests for api_client.
+ */
+class ApiClientTransportTest extends TestCase {
+
+	/**
+	 * Load the real client class (no WordPress required to read the base URL).
+	 */
+	public static function setUpBeforeClass(): void {
+		require_once dirname( __DIR__, 2 ) . '/polldaddy-client.php';
+	}
+
+	/**
+	 * The API base URL must use the https scheme.
+	 */
+	public function test_api_base_url_uses_https() {
+		$client = new \api_client( 'test-partner-guid', 'test-usercode' );
+
+		$this->assertStringStartsWith(
+			'https://',
+			$client->polldaddy_url,
+			'api_client::$polldaddy_url must use https.'
+		);
+	}
+}


### PR DESCRIPTION
Two changes to the legacy XML API client. Neither is subtle.

**It was making its API requests over plain `http://`.** Everything else in this
plugin already speaks https — the key exchange, oembed, all of it — and this one
old path didn't. It *was* https at one point (#5, back in 2018), then came back as
http when the client got reinstated for the v3 release, buried inside a big commit
where nobody caught it. `git blame` shows it as brand-new code, so it read as
intentional. It wasn't. Put it back to https, where it should have stayed.

**The `fsockopen()` fallback in `send_request()` is dead, so it's gone.**
`wp_remote_post()` has been available unconditionally since long before the oldest
WordPress this plugin supports (5.5). That branch — hand-rolling an HTTP request on
a raw socket — hasn't executed in years. Deleted. The guard stays, so if the HTTP
API is ever missing it fails cleanly instead of fataling.

And there's now a unit test pinning the scheme to https. The 2018 change didn't
have one, which is *exactly* how it rotted back to http three years later. Tests
exist so fixes stay fixed.

No behavior change for anyone whose WordPress has a working HTTP API — which is
everyone.
