### PR TITLE
Poll shortcode loader: robustness fixes (loop abort + re-init)

### DIFF
--- a/js/polldaddy-shortcode.js
+++ b/js/polldaddy-shortcode.js
@@ -8,20 +8,31 @@
 
 			if ( polls ){
 				$.each( polls, function() {
-					var poll = $( this ).data( 'settings' );
+					var poll_el = this;
+
+					// Only process each poll element once, even if render() runs
+					// again (e.g. on a later 'post-load' / 'pd-script-load' event).
+					if ( poll_el.getAttribute( 'data-pd-init-done' ) ) {
+						return;
+					}
+					poll_el.setAttribute( 'data-pd-init-done', '1' );
+
+					var poll = $( poll_el ).data( 'settings' );
 
 					if ( poll ) {
 						var poll_url = document.createElement("a");
 						poll_url.href = poll['url'];
+						// Skip this element with return, not return false: return false
+						// would break the whole $.each loop and hide later valid polls.
 						if ( poll_url.protocol !== 'https:' ) {
-							return false;
+							return;
 						}
 						if ( poll_url.hostname != 'secure.polldaddy.com' && poll_url.hostname != 'static.polldaddy.com' ) {
-							return false;
+							return;
 						}
 						var pathname = poll_url.pathname;
 						if ( ! /^\/p\/\d+\.js$/.test( pathname ) ) {
-							return false;
+							return;
 						}
 						var wp_pd_js = document.createElement('script');
 						wp_pd_js.type = 'text/javascript';
@@ -35,7 +46,15 @@
 
 			if ( ratings ){
 				$.each( ratings, function() {
-					var rating = $( this ).data( 'settings' );
+					var rating_el = this;
+
+					// Only process each rating element once.
+					if ( rating_el.getAttribute( 'data-pd-init-done' ) ) {
+						return;
+					}
+					rating_el.setAttribute( 'data-pd-init-done', '1' );
+
+					var rating = $( rating_el ).data( 'settings' );
 
 					if ( ! rating ) {
 						return;


### PR DESCRIPTION
Two non-security robustness fixes to `js/polldaddy-shortcode.js`, ported from the equivalent Jetpack loader. Follow-up to #169.

### 1. Don't abort the poll loop on one invalid poll
The poll loop used `$.each( polls, … )` with `return false` on a rejected/invalid poll. In jQuery, returning `false` from an `$.each` callback **breaks the entire loop**, so a single poll that fails validation would stop every *later* poll on the page from loading. Switched those to `return` (skip just that element). This matters more now that #169 rejects polls whose URL isn't `https:` with the expected host/path.

### 2. Process each element once (idempotency)
`render()` is bound to `post-load pd-script-load` and re-runs on every such event (e.g. infinite scroll), which re-appended each poll's `<script>` every time. Added a `data-pd-init-done` marker so each poll/rating element is handled only once. (Ratings were already guarded against double-construction by the `PDRTJS_<key>` check; this makes both paths consistent and matches Jetpack.)

No functional change to valid polls/ratings; `node --check` passes.