### PR TITLE
Enable the next-version placeholder for releases

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,12 @@ Configuration is stored in `.wp-env.json`:
    npm run build
    ```
 
+### Versioning new code
+
+When you add a `@since`, `@deprecated`, or a WordPress `_deprecated_*()` call for code that will ship in the **next** release, tag it with the next-version placeholder token instead of guessing the version number. Run `bash scripts/replace-next-version-tag.sh -h` for the exact token and the recognized `@since` / `@deprecated` / `_deprecated_*()` patterns.
+
+At release time, `make release` replaces the placeholder with the version being shipped and **fails** if any malformed token is left behind — so you never need to know the next version number while writing a PR. (The token is deliberately not written literally in this doc: the release step rewrites it wherever it appears in a tracked file.)
+
 ### Code Standards
 
 The project follows WordPress Coding Standards. Before submitting any code:

--- a/release.config.json
+++ b/release.config.json
@@ -5,5 +5,5 @@
 	"versionConstant": null,
 	"readme": "readme.txt",
 	"bumpPackageJson": true,
-	"nextVersionPlaceholder": false
+	"nextVersionPlaceholder": true
 }

--- a/scripts/includes/chalk-lite.sh
+++ b/scripts/includes/chalk-lite.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+
+# Test if color is supported.
+function color_supported {
+	[[ -n "$NO_COLOR" ]] && return 1
+	[[ -n "$FORCE_COLOR" ]] && return 0
+	[[ -t 1 ]]
+}
+
+# Print possibly-colored text to standard output.
+#
+# The first parameter is the ANSI SGR parameter string, i.e. the part that
+# goes in between the `\e[` and the `m`.
+#
+# If passed additional parameters, those are printed. Otherwise, lines are read
+# from standard input and printed. Examples:
+#
+#   chalk 31 'This prints red text'
+#
+#   chalk 31 <<EOM
+#   This also prints red text.
+#   EOM
+#
+#   chalk 31 'This prints red text to STDERR' >&2
+function chalk {
+	local CC="$1" LINE FMT
+	shift
+	if color_supported; then
+		FMT="\e[${CC}m%s\e[0m\n"
+	else
+		FMT="%s\n"
+	fi
+	if [[ $# -gt 0 ]]; then
+		printf "$FMT" "$*"
+	else
+		while IFS= read -r LINE; do
+			printf "$FMT" "$LINE"
+		done
+	fi
+}
+
+# All the rest of these functions are just wrappers around `chalk` that
+# supply a particular first argument. `error` and `warn` also output to STDERR
+# by default.
+#
+#   info "Here's some information"
+#
+#   error <<-EOM
+#   Something went wrong!
+#   EOM
+
+
+function debug {
+	chalk '1;30' "$@"
+}
+
+function success {
+	if [[ $(tput colors 2>/dev/null) -gt 8 ]]; then
+		chalk '1;38;5;41' "$@"
+	else
+		chalk '1;32' "$@"
+	fi
+}
+
+function info {
+	chalk '1;37' "$@"
+}
+
+function warn {
+	chalk '1;33' "$@" >&2
+}
+
+function error {
+	chalk '1;31' "$@" >&2
+}
+
+function die {
+	error "$@"
+	exit 1
+}
+
+function prompt {
+	yellow "$@"
+}
+
+function red {
+	chalk '31' "$@"
+}
+
+function green {
+	chalk '32' "$@"
+}
+
+function jetpackGreen {
+	if [[ $(tput colors 2>/dev/null) -gt 8 ]]; then
+		chalk '38;5;41' "$@"
+	else
+		chalk '32' "$@"
+	fi
+}
+
+function yellow {
+	chalk '33' "$@"
+}
+
+function blue {
+	chalk '34' "$@"
+}
+
+function purple {
+	chalk '35' "$@"
+}
+
+function cyan {
+	chalk '36' "$@"
+}

--- a/scripts/includes/proceed_p.sh
+++ b/scripts/includes/proceed_p.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+INTERACTIVE=true
+if [[ ! -t 0 ]]; then
+	INTERACTIVE=false
+fi
+
+. "$(dirname "$BASH_SOURCE[0]")/chalk-lite.sh"
+
+# Ask whether to proceed.
+#
+# Args:
+#  1: The situation that requires prompting.
+#  2: Optional text to replace "Proceed?" as the question.
+#
+# Returns success if "yes", failure if "no" or non-interactive.
+function proceed_p {
+	if ! $INTERACTIVE; then
+		error "$1 Aborting"
+		return 42
+	fi
+	local OK
+
+	# Clear input before prompting
+	while read -r -t 0 OK; do read -r OK; done
+
+	local PROMPT
+	[[ -n "$1" ]] && PROMPT="$1 "
+	PROMPT="${PROMPT}${2:-Proceed?} [y/N] "
+	if color_supported; then
+		PROMPT=$(FORCE_COLOR=1 prompt "$PROMPT")
+	fi
+
+	read -n 1 -p "$PROMPT" OK
+	echo ""
+	[[ "$OK" == "y" || "$OK" == "Y" ]]
+}

--- a/scripts/replace-next-version-tag.sh
+++ b/scripts/replace-next-version-tag.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+
+# Adapted from https://github.com/Automattic/jetpack/blob/b3179d4347dcf73269985e1801b61bf53fbc441a/tools/replace-next-version-tag.sh
+
+set -eo pipefail
+
+BASE=$(cd $(dirname "${BASH_SOURCE[0]}")/.. && pwd)
+. "$BASE/scripts/includes/chalk-lite.sh"
+. "$BASE/scripts/includes/proceed_p.sh"
+
+# Print help and exit.
+function usage {
+	cat <<-'EOH'
+		usage: $0 [-v] <version>
+
+		Replace the `$$next-version$$` token in doc tags with the specified version.
+		Recognized patterns:
+		 - `@since $$next-version$$`
+		 - `@deprecated $$next-version$$`
+		 - `@deprecated since $$next-version$$`
+		 - `_deprecated_function( ..., 'prefix-$$next-version$$' )`
+		   Other WordPress deprecation functions also work. The call must be on one
+		   line, indented with tabs, and the '$$next-version$$' token must be in a
+		   single-quoted string.
+	EOH
+	exit 1
+}
+
+if [[ $# -eq 0 ]]; then
+	usage
+fi
+
+# Sets options.
+VERBOSE=
+while getopts ":vh" opt; do
+	case ${opt} in
+		v)
+			if [[ -n "$VERBOSE" ]]; then
+				VERBOSE="${VERBOSE}v"
+			else
+				VERBOSE="-v"
+			fi
+			;;
+		h)
+			usage
+			;;
+		:)
+			die "Argument -$OPTARG requires a value."
+			;;
+		?)
+			error "Invalid argument: -$OPTARG"
+			echo ""
+			usage
+			;;
+	esac
+done
+shift "$(($OPTIND - 1))"
+
+if [[ -z "$VERBOSE" ]]; then
+	function debug {
+		:
+	}
+fi
+
+# Determine the version
+[[ -z "$1" ]] && die "A version must be specified."
+VERSION="$1"
+if ! grep -E -q '^[0-9]+(\.[0-9]+)+(-(a|alpha|beta)([-.]?[0-9]+)?)?$' <<<"$VERSION"; then
+	proceed_p "Version $VERSION does not seem to be a valid version number." "Continue?"
+fi
+VE=$(sed 's/[&\\/]/\\&/g' <<<"$VERSION")
+
+cd "$BASE"
+EXIT=0
+for FILE in $(git ls-files); do
+	[ "$FILE" == "scripts/replace-next-version-tag.sh" ] && continue;
+	grep -F -q '$$next-version$$' "$FILE" 2>/dev/null || continue
+	debug "Processing $FILE"
+
+	sed -i.bak -E -e 's!\$\$next-version\$\$!'"$VE"'!g' "$FILE"
+	rm "$FILE.bak" # We need a backup file because macOS requires it.
+
+	if grep -F -q '$$next-version$$' "$FILE"; then
+		EXIT=1
+		while IFS=':' read -r LINE DUMMY; do
+			if [[ -n "$CI" ]]; then
+				echo "::error file=$FILE,line=$LINE::"'Unexpected `$$next-version$$` token.'
+			else
+				error "$FILE:$LINE:"' Unexpected `$$next-version$$` token.'
+			fi
+		done < <( grep --line-number -F '$$next-version$$' "$FILE" || echo "" )
+	fi
+done
+
+exit $EXIT


### PR DESCRIPTION
Ports the shared next-version placeholder mechanism from wp-job-manager so contributors can tag new code without knowing the next version number.

## What this does

When you add an `@since` / `@deprecated` / `_deprecated_*()` for code shipping in the **next** release, tag it with the next-version placeholder token instead of a hard-coded version. At release, `make release` (via `scripts/replace-next-version-tag.sh`) replaces the token with the version being shipped and **fails** if any malformed token is left behind.

## Changes

- Add `scripts/replace-next-version-tag.sh` and `scripts/includes/{chalk-lite,proceed_p}.sh` — byte-identical to wp-job-manager's copies (the shared scripts stay identical across the plugin family).
- Set `nextVersionPlaceholder: true` in `release.config.json`. The shared `prepare-release.mjs` already gates the replacement step on this flag, so no orchestrator change is needed.
- Document the convention (see the doc change in this PR).

## Note on the docs

The replacement rewrites the literal token in **every** tracked file, so the doc describes the token and points to `replace-next-version-tag.sh -h` rather than printing it literally — matching wp-job-manager, whose tracked docs never contain the literal token. Otherwise the doc's own example would be rewritten at each release.

Verified locally: token replacement works on a sample file, and a release run is a no-op across the current tree.
