### PR TITLE
Exclude agent/dev docs from the release zip

### DIFF
--- a/scripts/build-plugin.sh
+++ b/scripts/build-plugin.sh
@@ -37,6 +37,9 @@ dev_paths=(
 	Makefile
 	CONTRIBUTING.md
 	README.md
+	AGENTS.md
+	CLAUDE.md
+	docs
 	release.config.json
 	scripts
 	screenshot-1.png


### PR DESCRIPTION
`build/polldaddy.zip` was packaging **AGENTS.md**, **CLAUDE.md**, and **docs/** (agent instructions + `docs/agents/`) and shipping them to WordPress.org — they were missing from the build's `dev_paths` exclusion list.

Fix: add `AGENTS.md`, `CLAUDE.md`, and `docs` to `dev_paths` in `scripts/build-plugin.sh`.

Verified by building the zip before/after: the three are gone and all plugin files remain. (Already shipped in 3.1.8; this applies to the next release.)