### PR TITLE
Derive upload usercode server-side

### DIFF
--- a/ajax.php
+++ b/ajax.php
@@ -22,8 +22,10 @@ class Polldaddy_Ajax {
 
 		check_admin_referer( 'send-media' );
 
-		$attach_id = $media_id = $user_code = 0;
-		$name = $url = '';
+		$attach_id = 0;
+		$media_id  = 0;
+		$name      = '';
+		$url       = '';
 
 		if ( isset( $_POST['attach-id'] ) )
 			$attach_id = (int) $_POST['attach-id'];
@@ -31,8 +33,10 @@ class Polldaddy_Ajax {
 		if ( isset( $_POST['media-id'] ) )
 			$media_id = (int) $_POST['media-id'];
 
-		if ( isset( $_POST['uc'] ) )
-			$user_code = $_POST['uc'];
+		$user_code = get_option( 'pd-usercode-' . get_current_user_id() );
+		if ( empty( $user_code ) ) {
+			$user_code = get_option( 'crowdsignal_user_code' );
+		}
 
 		if ( isset( $_POST['url'] ) )
 			$url = $_POST['url'];
@@ -55,7 +59,7 @@ class Polldaddy_Ajax {
 
 		if ( is_a( $response, "PollDaddy_Media" ) )
 			echo urldecode( $response->upload_result ).'||'.$media_id;
-		die();
+		wp_die();
 	}
 
 	public function ajax_add_answer() {

--- a/partials/poll-edit-form.php
+++ b/partials/poll-edit-form.php
@@ -17,7 +17,6 @@ $delete_media_link = '<a href="#" class="delete-media delete hidden" title="' . 
 <form enctype="multipart/form-data" name="send-media" action="admin-ajax.php" method="post">
 	<?php wp_nonce_field( 'send-media' ); ?>
 	<input type="hidden" value="" name="action">
-	<input type="hidden" value="<?php echo esc_attr( $controller->user_code ); ?>" name="uc">
 	<input type="hidden" value="" name="attach-id">
 	<input type="hidden" value="" name="media-id">
 	<input type="hidden" value="" name="url">

--- a/tests/Integration/Ajax/MediaActionsTest.php
+++ b/tests/Integration/Ajax/MediaActionsTest.php
@@ -20,6 +20,8 @@ class MediaActionsTest extends TestCase {
 
 	protected function tearDown(): void {
 		unset( $GLOBALS['polldaddy_test_is_private_blog'] );
+		$_POST    = array();
+		$_REQUEST = array();
 		parent::tearDown();
 	}
 
@@ -28,6 +30,84 @@ class MediaActionsTest extends TestCase {
 	 */
 	public function test_polls_upload_image_action_registered(): void {
 		$this->assertNotFalse( has_action( 'wp_ajax_polls_upload_image' ), 'polls_upload_image AJAX action should be registered' );
+	}
+
+	/**
+	 * Test that polls_upload_image derives the usercode from server-side options.
+	 *
+	 * @dataProvider polls_upload_image_user_code_provider
+	 *
+	 * @param string      $per_user_code    User-specific usercode option value.
+	 * @param string      $site_user_code   Site-wide usercode option value.
+	 * @param string|null $request_user_code Request-supplied usercode, when present.
+	 * @param string      $expected_user_code Expected usercode in the API request.
+	 */
+	public function test_polls_upload_image_derives_user_code_server_side( $per_user_code, $site_user_code, $request_user_code, $expected_user_code ): void {
+		$user_id = $this->create_test_user( array( 'edit_posts' ) );
+		wp_set_current_user( $user_id );
+
+		update_option( 'pd-usercode-' . $user_id, $per_user_code );
+		update_option( 'crowdsignal_user_code', $site_user_code );
+
+		$post_data = array(
+			'action'    => 'polls_upload_image',
+			'_wpnonce'  => wp_create_nonce( 'send-media' ),
+			'attach-id' => '0',
+			'media-id'  => '456',
+			'url'       => 'https://example.com/image.jpg',
+		);
+		if ( null !== $request_user_code ) {
+			$post_data['uc'] = $request_user_code;
+		}
+		$_POST    = $post_data;
+		$_REQUEST = $post_data;
+
+		$http_request_body = null;
+		$pre_http_request  = static function ( $preempt, $args ) use ( &$http_request_body ) {
+			$http_request_body = $args['body'];
+			return new \WP_Error( 'crowdsignal_test_http_request_blocked' );
+		};
+		add_filter( 'pre_http_request', $pre_http_request, 10, 2 );
+
+		$this->expectException( 'WPDieException' );
+
+		try {
+			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Testing the registered WordPress AJAX action.
+			do_action( 'wp_ajax_polls_upload_image' );
+		} finally {
+			remove_filter( 'pre_http_request', $pre_http_request );
+			delete_option( 'pd-usercode-' . $user_id );
+			delete_option( 'crowdsignal_user_code' );
+			wp_delete_user( $user_id );
+
+			$this->assertIsString( $http_request_body, 'The upload request should reach the HTTP transport.' );
+			$this->assertStringContainsString( '<pd:userCode>' . $expected_user_code . '</pd:userCode>', $http_request_body );
+			if ( null !== $request_user_code ) {
+				$this->assertStringNotContainsString( $request_user_code, $http_request_body );
+			}
+		}
+	}
+
+	/**
+	 * Data provider for server-side upload usercode derivation.
+	 *
+	 * @return array<string, array{string, string, string|null, string}>
+	 */
+	public function polls_upload_image_user_code_provider(): array {
+		return array(
+			'per-user option ignores request value'      => array(
+				'per-user-code',
+				'site-user-code',
+				'request-user-code',
+				'per-user-code',
+			),
+			'site option fallback without request value' => array(
+				'',
+				'site-user-code',
+				null,
+				'site-user-code',
+			),
+		);
 	}
 
 	/**


### PR DESCRIPTION
Fixes #153

## Changes proposed in this Pull Request

The upload handler previously treated the hidden `uc` form field as the source of truth even though the current user's account code is already stored server-side.

- Derive the upload usercode from the current user's `pd-usercode-*` option.
- Fall back to the site-wide `crowdsignal_user_code` option when the per-user value is empty.
- Remove the hidden `uc` field from the poll editor form.
- Use `wp_die()` for the AJAX response exit so the handler can be exercised by the WordPress test suite.
- Add integration coverage proving the per-user value wins, the fallback works, and a request-supplied value is ignored.

Authenticated poll image uploads now use the configured server-side account value and cannot be redirected to a different usercode through the request.

## Testing instructions

1. Start the test environment:

   ```bash
   wp-env start
   ```

2. Run the complete unit and integration test suites:

   ```bash
   wp-env run tests-cli --env-cwd=wp-content/plugins/crowdsignal-plugin composer test
   ```

3. Confirm both suites pass, including the two `polls_upload_image` usercode data sets.

## Screenshot or video

Not applicable; there are no visual changes.
