### PR TITLE
Harden shared release tooling (sync with jetpack-crm)

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   deploy:
-    if: github.event.pull_request.merged == true && startsWith( github.head_ref, 'release/' )
+    if: github.event.pull_request.merged == true && startsWith( github.head_ref, 'release/' ) && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     name: Polldaddy Release
     # The default GITHUB_TOKEN is read-only on repos that don't opt into
@@ -20,7 +20,7 @@ jobs:
       pull-requests: write
       issues: write
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # Check out the PR's base branch (trunk) as a real local branch, not the
           # detached-HEAD merge ref, so create-release.mjs can `git push origin HEAD`.
@@ -30,7 +30,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: gh pr comment ${{ github.event.number }} --body "🚀 **[Release workflow started](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})**"
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
       - name: Install JS dependencies

--- a/.github/workflows/lint-next-version.yml
+++ b/.github/workflows/lint-next-version.yml
@@ -7,7 +7,7 @@ jobs:
   next-version-tags:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
       - name: Check $$next-version$$ usage in added lines

--- a/scripts/prepare-release.mjs
+++ b/scripts/prepare-release.mjs
@@ -47,6 +47,14 @@ if ( ! /^\d+(\.\d+)+(-(a|alpha|beta)([-.]?\d+)?)?$/.test( version ) ) {
 	process.exit( 1 );
 }
 
+// A release must be cut from a clean tree. The branch is created from the
+// current HEAD and `replaceNextVersionPlaceholder()` stages with `git add -u`,
+// which would sweep any modified tracked files into the release commit. Scope
+// the check to tracked changes: untracked files are never staged by the release
+// steps, so blocking on them would be a false positive. Fail fast, before the
+// confirmation prompt or any branch creation.
+assertCleanWorkingTree();
+
 const ghPrs = `gh pr list -R ${ cfg.repo } --state merged --base ${ BASE_BRANCH } --limit 500 --search "milestone:${ version }"`;
 
 // Confirm release through CLI.
@@ -97,6 +105,23 @@ function readFileContents( filepath ) {
 		return fs.readFileSync( filepath, 'utf8' );
 	} catch ( err ) {
 		throw new Error( `File (${ filepath }) could not be read.` );
+	}
+}
+
+/**
+ * Abort unless the working tree has no uncommitted changes to tracked files.
+ *
+ * A dirty tree is unsafe for a release: the release branch is cut from the
+ * current HEAD and `replaceNextVersionPlaceholder()` runs `git add -u`, which
+ * stages every modified tracked file — so stray edits would land in the release
+ * PR. Untracked files are excluded because no release step stages them.
+ */
+function assertCleanWorkingTree() {
+	const status = execSync( 'git status --porcelain --untracked-files=no' ).toString().trim();
+	if ( status ) {
+		console.log( chalk.bold.red( 'Error: the working tree has uncommitted changes to tracked files. Commit, stash or discard them before preparing a release.' ) );
+		console.log( status );
+		process.exit( 1 );
 	}
 }
 
@@ -322,6 +347,10 @@ function pushBranch() {
 /**
  * Revert the workspace to its original state.
  *
+ * Also deletes the release branch on the remote if it was already pushed (e.g.
+ * `createPR()` failed after `pushBranch()` succeeded) — otherwise the orphaned
+ * remote branch would block a retry, which recreates the same branch name.
+ *
  * @param {string} originalBranch The original branch name.
  * @param {string} branchToDelete The release branch to delete.
  */
@@ -330,4 +359,20 @@ function revertOnError( originalBranch, branchToDelete ) {
 	execSync( `git checkout . && git checkout ${ originalBranch }` );
 	console.log( `Deleting '${ branchToDelete }'....` );
 	execSync( `git branch -D ${ branchToDelete }` );
+
+	// Delete the remote branch too, but only if it exists. `git ls-remote
+	// --exit-code` exits non-zero when the branch isn't on the remote, so a
+	// throw here means "nothing to clean up".
+	try {
+		execSync( `git ls-remote --exit-code --heads ${ REMOTE } ${ branchToDelete }`, { stdio: 'ignore' } );
+	} catch {
+		return;
+	}
+	console.log( `Deleting '${ branchToDelete }' on ${ REMOTE }....` );
+	try {
+		execSync( `git push ${ REMOTE } --delete ${ branchToDelete }` );
+	} catch {
+		// Best-effort: don't let a failed remote cleanup mask the original error.
+		console.log( chalk.yellow( `Could not delete '${ branchToDelete }' on ${ REMOTE }; delete it manually before retrying.` ) );
+	}
 }


### PR DESCRIPTION
Ports four release-tooling hardening fixes from `Automattic/jetpack-crm` to keep the shared, config-driven release system identical across the plugin family. No behavioral change to a normal, clean release.

## Changes

1. **Clean-tree guard** (`scripts/prepare-release.mjs`) — new `assertCleanWorkingTree()` runs before the confirmation prompt / branch creation and aborts if the working tree has uncommitted changes to *tracked* files. Otherwise `replaceNextVersionPlaceholder()`'s `git add -u` would sweep unrelated edits into the release commit. Untracked files are intentionally ignored (no release step stages them).

2. **Remote-branch rollback cleanup** (`scripts/prepare-release.mjs`) — `revertOnError()` now also deletes the release branch on `origin` when it was already pushed (e.g. `createPR()` failed after `pushBranch()`), so an orphaned remote branch can't block a retry. Best-effort: existence is checked with `git ls-remote --exit-code` and a failed remote delete won't mask the original error.

3. **Fork-merge deploy guard** (`.github/workflows/create-release.yml`) — the `deploy` job's `if:` gains `github.event.pull_request.head.repo.full_name == github.repository` so it only runs for same-repo (non-fork) `release/*` merges.

4. **SHA-pin actions** (both release workflows) — every `uses:` in `create-release.yml` and `lint-next-version.yml` is pinned to a 40-hex commit SHA with the original ref kept as a trailing comment (supply-chain hardening). Versions were pinned as-is, not upgraded.

The pre-push hook + `make install-hooks` guard already exists in this repo, so it was not re-added.