### PR TITLE
Exempt release PRs from the next-version lint

### DIFF
--- a/.github/workflows/lint-next-version.yml
+++ b/.github/workflows/lint-next-version.yml
@@ -5,6 +5,15 @@ on:
 
 jobs:
   next-version-tags:
+    # Release PRs are exempt. prepare-release.mjs rewrites every $$next-version$$
+    # to the real version as part of cutting the branch, so the substituted @since
+    # lines fail this check on every release. Feature PRs, where a hand-written
+    # version is a genuine mistake, are what it exists for.
+    #
+    # This has to be a head_ref test rather than a `branches-ignore:` filter,
+    # because for pull_request those filters match the base branch, and a release
+    # PR targets trunk like any other.
+    if: ${{ ! startsWith(github.head_ref, 'release/') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4


### PR DESCRIPTION

prepare-release.mjs runs replaceNextVersionPlaceholder() when it cuts the release
branch, so every $$next-version$$ becomes the real version. This check then sees
added lines carrying a hard-coded one and fails, on every release. The script's
"next-version-ok" escape hatch is no help, because nothing can put that marker on
lines the release script generates.

The check is for feature PRs, where a hand-written version is a real mistake.

It has to be a head_ref test. `branches-ignore:` is wrong here: for pull_request
those filters match the base branch, and a release PR targets trunk like anything
else, so it would skip nothing.

Shared release tooling, synced from Automattic/jetpack-crm#43, where a 6.8.3
release PR hit this first.